### PR TITLE
feat: advanced row selection, shift+arrow range navigation, and column editor hideToggle feature

### DIFF
--- a/apps/marketing/src/constants/propDefinitions/configProps.ts
+++ b/apps/marketing/src/constants/propDefinitions/configProps.ts
@@ -399,6 +399,15 @@ export const COLUMN_EDITOR_CONFIG_PROPS: PropInfo[] = [
     example: `{ allowColumnPinning: false }`,
   },
   {
+    key: "hideToggle",
+    name: "hideToggle",
+    required: false,
+    description:
+      "Hides the column editor side toggle completely. When true, the editor does not occupy 29.5px layout space and must be opened programmatically via `tableRef.current.toggleColumnEditor()`. Defaults to false.",
+    type: "boolean",
+    example: `{ hideToggle: true }`,
+  },
+  {
     key: "rowRenderer",
     name: "rowRenderer",
     required: false,

--- a/apps/marketing/src/constants/propDefinitions/simpleTableProps.ts
+++ b/apps/marketing/src/constants/propDefinitions/simpleTableProps.ts
@@ -872,7 +872,7 @@ useEffect(() => {
     key: "rowButtons",
     name: "rowButtons",
     required: false,
-    description: "Array of buttons to show in each row.",
+    description: "Array of buttons to show in each row. Requires `enableRowSelection` to be true as these render inside the selection column. Use `customTheme.selectionColumnWidth` to adjust the width. Note: functions must return vanilla HTMLElements.",
     type: "RowButton[]",
     example: `rowButtons={[
   ({ row }) => <button onClick={() => editRow(row)}>Edit</button>,

--- a/packages/core/src/core/SimpleTableVanilla.ts
+++ b/packages/core/src/core/SimpleTableVanilla.ts
@@ -165,6 +165,7 @@ export class SimpleTableVanilla {
 
   constructor(container: HTMLElement, config: SimpleTableConfig) {
     this.container = container;
+    config = TableInitializer.resolveConfigDefaults(config);
     this.config = config;
 
     this.customTheme = TableInitializer.mergeCustomTheme(config);
@@ -1112,7 +1113,7 @@ export class SimpleTableVanilla {
 
   update(config: Partial<SimpleTableConfig>): void {
     this.isUpdating = true;
-    this.config = { ...this.config, ...config };
+    this.config = TableInitializer.resolveConfigDefaults({ ...this.config, ...config });
 
     if (config.animations !== undefined) {
       this.applyAnimationsConfig(config.animations);

--- a/packages/core/src/core/SimpleTableVanilla.ts
+++ b/packages/core/src/core/SimpleTableVanilla.ts
@@ -417,6 +417,8 @@ export class SimpleTableVanilla {
       copyHeadersToClipboard: this.config.copyHeadersToClipboard,
       customTheme: this.customTheme,
       tableRoot: this.container,
+      rowSelectionConfig: this.config.rowSelectionConfig,
+      rowSelectionManager: this.rowSelectionManager,
       onSelectionDragEnd: () => {
         this.renderOrchestrator.invalidateCache("context");
         this.renderOrchestrator.invalidateCache("body");
@@ -1205,12 +1207,15 @@ export class SimpleTableVanilla {
     }
 
     if (
-      (config.selectableColumns !== undefined || config.selectableCells !== undefined) &&
+      (config.selectableColumns !== undefined ||
+        config.selectableCells !== undefined ||
+        config.rowSelectionConfig !== undefined) &&
       this.selectionManager
     ) {
       this.selectionManager.updateConfig({
         selectableColumns: this.config.selectableColumns ?? false,
         selectableCells: this.config.selectableCells ?? false,
+        rowSelectionConfig: this.config.rowSelectionConfig,
       });
     }
 
@@ -1339,6 +1344,7 @@ export class SimpleTableVanilla {
       getCachedProcessedResult: () => this.renderOrchestrator.getLastProcessedResult(),
       expandedDepthsManager: this.expandedDepthsManager,
       selectionManager: this.selectionManager,
+      rowSelectionManager: this.rowSelectionManager,
       sortManager: this.sortManager,
       filterManager: this.filterManager,
       onRender: () => this.render("columnEditor-onRender"),

--- a/packages/core/src/core/api/TableAPIImpl.ts
+++ b/packages/core/src/core/api/TableAPIImpl.ts
@@ -24,6 +24,8 @@ import {
 } from "../../utils/pinnedColumnUtils";
 import { PinnedSectionsState } from "../../types/PinnedSectionsState";
 import { deepClone } from "../../utils/generalUtils";
+import { rowIdToString } from "../../utils/rowUtils";
+import { RowSelectionManager } from "../../managers/RowSelectionManager";
 
 export interface TableAPIContext {
   config: SimpleTableConfig;
@@ -46,6 +48,7 @@ export interface TableAPIContext {
   columnEditorOpen: boolean;
   expandedDepthsManager: any;
   selectionManager: SelectionManager | null;
+  rowSelectionManager: RowSelectionManager | null;
   sortManager: SortManager | null;
   filterManager: FilterManager | null;
   getCachedFlattenResult?: () => FlattenRowsResult | null;
@@ -379,6 +382,27 @@ export class TableAPIImpl {
 
       selectCellRange: (startCell: Cell, endCell: Cell) => {
         context.selectionManager?.selectCellRange(startCell, endCell);
+      },
+
+      toggleRowSelection: (rowId: string, isSelected?: boolean) => {
+        if (context.rowSelectionManager) {
+          const targetState = isSelected !== undefined ? isSelected : !context.rowSelectionManager.isRowSelected(rowId);
+          context.rowSelectionManager.handleRowSelect(rowId, targetState);
+        }
+      },
+
+      getSelectedRows: (): string[] => {
+        if (context.rowSelectionManager) {
+          return Array.from(context.rowSelectionManager.getSelectedRows());
+        }
+        return [];
+      },
+
+      getRow: (rowId: string): any | null => {
+        const flatRow = getFlattenResult().flattenedRows.find(
+          (tr) => rowIdToString(tr.rowId) === rowId
+        );
+        return flatRow ? flatRow.row : null;
       },
     };
   }

--- a/packages/core/src/core/dom/DOMManager.ts
+++ b/packages/core/src/core/dom/DOMManager.ts
@@ -72,8 +72,10 @@ export class DOMManager {
     content.setAttribute("role", isTreeGrid ? "treegrid" : "grid");
     // Match RenderOrchestrator so DimensionManager's first clientWidth read (before any render)
     // already excludes the column editor strip when editColumns is on.
-    content.style.width = config.editColumns
-      ? `calc(100% - ${COLUMN_EDIT_WIDTH}px)`
+    const hideToggle = config.columnEditorConfig?.hideToggle ?? false;
+    const editorWidth = config.editColumns && !hideToggle ? COLUMN_EDIT_WIDTH : 0;
+    content.style.width = editorWidth > 0
+      ? `calc(100% - ${editorWidth}px)`
       : "100%";
 
     const headerContainer = document.createElement("div");

--- a/packages/core/src/core/initialization/TableInitializer.ts
+++ b/packages/core/src/core/initialization/TableInitializer.ts
@@ -32,6 +32,7 @@ export interface MergedColumnEditorConfig {
   searchEnabled: boolean;
   searchPlaceholder: string;
   allowColumnPinning: boolean;
+  hideToggle: boolean;
   searchFunction?: (header: HeaderObject, searchText: string) => boolean;
   rowRenderer?: ColumnEditorRowRenderer;
   customRenderer?: ColumnEditorCustomRenderer;
@@ -82,6 +83,9 @@ export class TableInitializer {
       allowColumnPinning:
         config.columnEditorConfig?.allowColumnPinning ??
         DEFAULT_COLUMN_EDITOR_CONFIG.allowColumnPinning,
+      hideToggle:
+        config.columnEditorConfig?.hideToggle ??
+        DEFAULT_COLUMN_EDITOR_CONFIG.hideToggle,
       searchFunction: config.columnEditorConfig?.searchFunction,
       rowRenderer: config.columnEditorConfig?.rowRenderer,
       customRenderer: config.columnEditorConfig?.customRenderer,

--- a/packages/core/src/core/initialization/TableInitializer.ts
+++ b/packages/core/src/core/initialization/TableInitializer.ts
@@ -1,4 +1,5 @@
 import { SimpleTableConfig } from "../../types/SimpleTableConfig";
+import { RowSelectionConfig } from "../../types/SimpleTableProps";
 import { CustomTheme, DEFAULT_CUSTOM_THEME } from "../../types/CustomTheme";
 import { DEFAULT_COLUMN_EDITOR_CONFIG } from "../../types/ColumnEditorConfig";
 import { ColumnEditorRowRenderer } from "../../types/ColumnEditorRowRendererProps";
@@ -116,10 +117,28 @@ export class TableInitializer {
     return initializeExpandedDepths(config.expandAll ?? true, config.rowGrouping);
   }
 
-  static resolveConfigDefaults<T extends { selectableCells?: boolean; selectableColumns?: boolean }>(config: T): T {
+  static resolveConfigDefaults<T extends {
+    selectableCells?: boolean;
+    selectableColumns?: boolean;
+    enableRowSelection?: boolean;
+    rowSelectionConfig?: RowSelectionConfig;
+  }>(config: T): T {
     const resolved = { ...config };
     if (resolved.selectableCells && resolved.selectableColumns === undefined) {
       resolved.selectableColumns = true;
+    }
+    if (resolved.enableRowSelection) {
+      const originalConfig = resolved.rowSelectionConfig || {};
+      const showCheckboxes = originalConfig.showCheckboxes ?? true;
+      resolved.rowSelectionConfig = {
+        showCheckboxes,
+        enableClickSelection: originalConfig.enableClickSelection ?? (!showCheckboxes ? true : false),
+        enableKeyboardNavigation: originalConfig.enableKeyboardNavigation ?? (!showCheckboxes ? true : false),
+        mode: originalConfig.mode ?? 'multi',
+      };
+      if (!showCheckboxes) {
+        resolved.selectableCells = false;
+      }
     }
     return resolved;
   }

--- a/packages/core/src/core/initialization/TableInitializer.ts
+++ b/packages/core/src/core/initialization/TableInitializer.ts
@@ -115,4 +115,12 @@ export class TableInitializer {
   static getInitialExpandedDepths(config: SimpleTableConfig): Set<number> {
     return initializeExpandedDepths(config.expandAll ?? true, config.rowGrouping);
   }
+
+  static resolveConfigDefaults<T extends { selectableCells?: boolean; selectableColumns?: boolean }>(config: T): T {
+    const resolved = { ...config };
+    if (resolved.selectableCells && resolved.selectableColumns === undefined) {
+      resolved.selectableColumns = true;
+    }
+    return resolved;
+  }
 }

--- a/packages/core/src/core/rendering/RenderOrchestrator.ts
+++ b/packages/core/src/core/rendering/RenderOrchestrator.ts
@@ -184,7 +184,8 @@ export class RenderOrchestrator {
   ): HeaderObject[] {
     let processedHeaders = [...headers];
 
-    if (config.enableRowSelection && !headers?.[0]?.isSelectionColumn) {
+    const showSelectionColumn = config.enableRowSelection && (config.rowSelectionConfig?.showCheckboxes !== false);
+    if (showSelectionColumn && !headers?.[0]?.isSelectionColumn) {
       const selectionHeader = createSelectionHeader(customTheme.selectionColumnWidth);
       processedHeaders = [selectionHeader, ...processedHeaders];
     }

--- a/packages/core/src/core/rendering/RenderOrchestrator.ts
+++ b/packages/core/src/core/rendering/RenderOrchestrator.ts
@@ -579,11 +579,13 @@ export class RenderOrchestrator {
       );
 
       const { customTheme } = context;
+      const hideToggle = mergedColumnEditorConfig.hideToggle ?? false;
+      const editorWidth = context.config.editColumns && !hideToggle ? COLUMN_EDIT_WIDTH : 0;
       rootStyle.setProperty("--st-main-section-width", `${mainSectionContainerWidth}px`);
       rootStyle.setProperty("--st-scrollbar-width", `${state.scrollbarWidth}px`);
       rootStyle.setProperty(
         "--st-editor-width",
-        `${context.config.editColumns ? COLUMN_EDIT_WIDTH : 0}px`,
+        `${editorWidth}px`,
       );
       rootStyle.setProperty("--st-border-width", `${customTheme.borderWidth}px`);
       rootStyle.setProperty("--st-footer-height", `${customTheme.footerHeight}px`);
@@ -596,8 +598,8 @@ export class RenderOrchestrator {
 
       const columnResizing = context.config.columnResizing ?? false;
       elements.content.className = `st-content ${columnResizing ? "st-resizeable" : "st-not-resizeable"}`;
-      elements.content.style.width = context.config.editColumns
-        ? `calc(100% - ${COLUMN_EDIT_WIDTH}px)`
+      elements.content.style.width = editorWidth > 0
+        ? `calc(100% - ${editorWidth}px)`
         : "100%";
 
       this.renderHeader(

--- a/packages/core/src/core/rendering/TableRenderer.ts
+++ b/packages/core/src/core/rendering/TableRenderer.ts
@@ -456,6 +456,7 @@ export class TableRenderer {
       rowsWithSelectedCells: deps.selectionManager?.getRowsWithSelectedCells() ?? new Set(),
       columnBorders: deps.config.columnBorders ?? false,
       enableRowSelection: deps.config.enableRowSelection,
+      rowSelectionConfig: deps.config.rowSelectionConfig,
       selectedRowCount,
       cellUpdateFlash: deps.config.cellUpdateFlash,
       useOddColumnBackground: deps.config.useOddColumnBackground,
@@ -477,6 +478,9 @@ export class TableRenderer {
       onRowGroupExpand: deps.config.onRowGroupExpand,
       handleRowSelect: (rowId: string, checked: boolean) => {
         deps.rowSelectionManager?.handleRowSelect(rowId, checked);
+      },
+      handleRowClick: (rowId: string, rowIndex: number, shiftKey: boolean, ctrlKey: boolean) => {
+        deps.selectionManager?.handleRowClick(rowId, rowIndex, shiftKey, ctrlKey);
       },
       cellRegistry: deps.cellRegistry,
       getCollapsedRows: () => deps.getCollapsedRows(),

--- a/packages/core/src/core/rendering/TableRenderer.ts
+++ b/packages/core/src/core/rendering/TableRenderer.ts
@@ -726,6 +726,7 @@ export class TableRenderer {
           collapsedHeaders: deps.collapsedHeaders,
           customTheme: deps.customTheme,
           editColumns: deps.config.editColumns ?? false,
+          hideToggle: deps.config.columnEditorConfig?.hideToggle ?? false,
           headers: deps.effectiveHeaders,
           rowHeight: deps.customTheme.rowHeight,
           heightOffsets: processedResult.paginatedHeightOffsets,
@@ -924,6 +925,7 @@ export class TableRenderer {
         columnEditorConfig: mergedColumnEditorConfig,
         icons: deps.resolvedIcons,
         essentialAccessors: deps.essentialAccessors,
+        hideToggle: mergedColumnEditorConfig.hideToggle,
         setHeaders: (newHeaders: HeaderObject[]) => {
           deps.setHeaders(newHeaders);
           if (this.columnEditorInstance) {
@@ -950,6 +952,7 @@ export class TableRenderer {
         columnEditorConfig: mergedColumnEditorConfig,
         icons: deps.resolvedIcons,
         essentialAccessors: deps.essentialAccessors,
+        hideToggle: mergedColumnEditorConfig.hideToggle,
         setHeaders: (newHeaders: HeaderObject[]) => {
           deps.setHeaders(newHeaders);
           if (this.columnEditorInstance) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,7 +73,7 @@ import type { ColumnEditorConfig, ColumnEditorSearchFunction } from "./types/Col
 import type { IconsConfig } from "./types/IconsConfig";
 import type { GetRowId, GetRowIdParams } from "./types/GetRowId";
 import type { SimpleTableConfig } from "./types/SimpleTableConfig";
-import type { SimpleTableProps } from "./types/SimpleTableProps";
+import type { SimpleTableProps, RowSelectionConfig } from "./types/SimpleTableProps";
 import type { AnimationsConfig } from "./types/AnimationsConfig";
 import type { RowId } from "./types/RowId";
 import type { PinnedSectionsState } from "./types/PinnedSectionsState";
@@ -140,6 +140,7 @@ export type {
   RowButtonProps,
   RowId,
   RowSelectionChangeProps,
+  RowSelectionConfig,
   RowState,
   SetHeaderRenameProps,
   SharedTableProps,

--- a/packages/core/src/managers/SelectionManager/SelectionManager.ts
+++ b/packages/core/src/managers/SelectionManager/SelectionManager.ts
@@ -34,6 +34,7 @@ export class SelectionManager {
   private warningFlashCells: Set<string> = new Set();
   private isSelecting: boolean = false;
   private startCell: Cell | null = null;
+  private rowAnchorIndex: number | null = null;
 
   // Event handlers that need to be cleaned up
   private keydownHandler: ((event: KeyboardEvent) => void) | null = null;
@@ -208,7 +209,8 @@ export class SelectionManager {
    * Handle keyboard events for navigation and clipboard operations
    */
   private handleKeyDown(event: KeyboardEvent): void {
-    if (!this.config.selectableCells) return;
+    const isRowKeyboardNav = Boolean(this.config.rowSelectionConfig?.enableKeyboardNavigation) && Boolean(this.config.rowSelectionManager);
+    if (!this.config.selectableCells && !isRowKeyboardNav) return;
     if (!this.initialFocusedCell) return;
 
     // Don't intercept if user is typing in a form element
@@ -279,6 +281,10 @@ export class SelectionManager {
       if (currentRowIndex !== -1) {
         rowIndex = currentRowIndex;
       } else return;
+    }
+
+    if (this.handleRowKeyboardNavigation(event, rowIndex, colIndex)) {
+      return;
     }
 
     // Handle keyboard navigation
@@ -1382,21 +1388,29 @@ export class SelectionManager {
    * Handle mouse down on a cell to start selection
    */
   handleMouseDown({ colIndex, rowIndex, rowId }: Cell): void {
-    if (!this.config.selectableCells) return;
+    const isRowSelection = !this.config.selectableCells && Boolean(this.config.rowSelectionConfig?.enableClickSelection) && Boolean(this.config.rowSelectionManager);
+    if (!this.config.selectableCells && !isRowSelection) return;
 
     this.fullTableSelected = false;
     this.isSelecting = true;
     this.startCell = { rowIndex, colIndex, rowId };
 
-    setTimeout(() => {
-      this.selectedColumns = new Set();
-      this.lastSelectedColumnIndex = null;
-      const cellId = createSetString({ colIndex, rowIndex, rowId });
-      this.selectedCells = new Set([cellId]);
+    if (isRowSelection) {
+      this.rowAnchorIndex = rowIndex;
       this.initialFocusedCell = { rowIndex, colIndex, rowId };
-      this.updateDerivedState();
-      this.updateAllCellClasses();
-    }, 0);
+      const newSelected = new Set<string>([String(rowId)]);
+      this.config.rowSelectionManager!.setSelectedRows(newSelected);
+    } else {
+      setTimeout(() => {
+        this.selectedColumns = new Set();
+        this.lastSelectedColumnIndex = null;
+        const cellId = createSetString({ colIndex, rowIndex, rowId });
+        this.selectedCells = new Set([cellId]);
+        this.initialFocusedCell = { rowIndex, colIndex, rowId };
+        this.updateDerivedState();
+        this.updateAllCellClasses();
+      }, 0);
+    }
 
     this.currentMouseX = null;
     this.currentMouseY = null;
@@ -1444,10 +1458,129 @@ export class SelectionManager {
    * so virtualization/recycled DOM does not apply stale cellData from the firing element.
    */
   handleMouseOver(cellFromElement: Cell, clientX: number, clientY: number): void {
-    if (!this.config.selectableCells) return;
+    const isRowSelection = !this.config.selectableCells && Boolean(this.config.rowSelectionConfig?.enableClickSelection) && Boolean(this.config.rowSelectionManager);
+    if (!this.config.selectableCells && !isRowSelection) return;
+
     if (this.isSelecting && this.startCell) {
       const resolved = this.getCellFromMousePosition(clientX, clientY) ?? cellFromElement;
-      this.updateSelectionRange(this.startCell, resolved);
+      if (isRowSelection) {
+        const start = Math.min(this.startCell.rowIndex, resolved.rowIndex);
+        const end = Math.max(this.startCell.rowIndex, resolved.rowIndex);
+        const newSelected = new Set<string>();
+        for (let i = start; i <= end; i++) {
+          const tr = this.config.tableRows[i];
+          if (tr) {
+            newSelected.add(rowIdToString(tr.rowId));
+          }
+        }
+        this.config.rowSelectionManager!.setSelectedRows(newSelected);
+      } else {
+        this.updateSelectionRange(this.startCell, resolved);
+      }
     }
+  }
+
+  handleRowClick(rowId: string, rowIndex: number, shiftKey: boolean, ctrlKey: boolean): void {
+    const rowSelectionManager = this.config.rowSelectionManager;
+    if (!rowSelectionManager) return;
+
+    const mode = this.config.rowSelectionConfig?.mode ?? 'multi';
+
+    if (mode === 'single') {
+      const newSelected = new Set<string>([rowId]);
+      rowSelectionManager.setSelectedRows(newSelected);
+      this.rowAnchorIndex = rowIndex;
+      return;
+    }
+
+    if (ctrlKey) {
+      const wasSelected = rowSelectionManager.isRowSelected(rowId);
+      rowSelectionManager.handleRowSelect(rowId, !wasSelected);
+      this.rowAnchorIndex = rowIndex;
+    } else if (shiftKey && this.rowAnchorIndex !== null) {
+      const start = Math.min(this.rowAnchorIndex, rowIndex);
+      const end = Math.max(this.rowAnchorIndex, rowIndex);
+      const newSelected = new Set<string>();
+      for (let i = start; i <= end; i++) {
+        const tr = this.config.tableRows[i];
+        if (tr) {
+          newSelected.add(rowIdToString(tr.rowId));
+        }
+      }
+      rowSelectionManager.setSelectedRows(newSelected);
+    } else {
+      const newSelected = new Set<string>([rowId]);
+      rowSelectionManager.setSelectedRows(newSelected);
+      this.rowAnchorIndex = rowIndex;
+    }
+  }
+
+  private handleRowKeyboardNavigation(event: KeyboardEvent, rowIndex: number, colIndex: number): boolean {
+    const isRowSelection = !this.config.selectableCells && Boolean(this.config.rowSelectionConfig?.enableKeyboardNavigation) && Boolean(this.config.rowSelectionManager);
+    if (!isRowSelection) return false;
+
+    let newRowIndex = rowIndex;
+
+    if (event.key === "ArrowUp") {
+      newRowIndex = Math.max(0, rowIndex - 1);
+    } else if (event.key === "ArrowDown") {
+      newRowIndex = Math.min(this.config.tableRows.length - 1, rowIndex + 1);
+    } else if (event.key === "Home") {
+      newRowIndex = 0;
+    } else if (event.key === "End") {
+      newRowIndex = this.config.tableRows.length - 1;
+    } else {
+      return false;
+    }
+
+    event.preventDefault();
+
+    const targetRow = this.config.tableRows[newRowIndex];
+    if (!targetRow) return true;
+    const targetRowId = rowIdToString(targetRow.rowId);
+
+    // Update focused cell / row position
+    this.initialFocusedCell = { rowIndex: newRowIndex, colIndex, rowId: targetRowId };
+
+    const mode = this.config.rowSelectionConfig?.mode ?? 'multi';
+    if (mode === 'single') {
+      const newSelected = new Set<string>([targetRowId]);
+      this.config.rowSelectionManager!.setSelectedRows(newSelected);
+      this.rowAnchorIndex = newRowIndex;
+    } else {
+      if (event.shiftKey) {
+        if (this.rowAnchorIndex === null || this.rowAnchorIndex === undefined) {
+          this.rowAnchorIndex = rowIndex;
+        }
+        const start = Math.min(this.rowAnchorIndex, newRowIndex);
+        const end = Math.max(this.rowAnchorIndex, newRowIndex);
+        const newSelected = new Set<string>();
+        for (let i = start; i <= end; i++) {
+          const tr = this.config.tableRows[i];
+          if (tr) {
+            newSelected.add(rowIdToString(tr.rowId));
+          }
+        }
+        this.config.rowSelectionManager!.setSelectedRows(newSelected);
+      } else {
+        const newSelected = new Set<string>([targetRowId]);
+        this.config.rowSelectionManager!.setSelectedRows(newSelected);
+        this.rowAnchorIndex = newRowIndex;
+      }
+    }
+
+    // Scroll into view
+    setTimeout(() => {
+      if (this.initialFocusedCell) {
+        scrollCellIntoView(
+          this.initialFocusedCell,
+          this.config.rowHeight,
+          this.config.customTheme,
+          this.config.tableRows,
+        );
+      }
+    }, 0);
+
+    return true;
   }
 }

--- a/packages/core/src/managers/SelectionManager/SelectionManager.ts
+++ b/packages/core/src/managers/SelectionManager/SelectionManager.ts
@@ -336,11 +336,13 @@ export class SelectionManager {
         this.startCell = this.initialFocusedCell!;
       }
 
-      let targetRow = rowIndex - 1;
-
-      if (event.ctrlKey || event.metaKey) {
-        const edge = this.findEdgeInDirection(rowIndex, colIndex, "up");
-        targetRow = edge.rowIndex;
+      let targetRow: number;
+      if (rowIndex > this.startCell.rowIndex) {
+        // Collapse selection upwards back to the anchor row
+        targetRow = this.startCell.rowIndex;
+      } else {
+        // Expand selection upwards all the way to the top
+        targetRow = 0;
       }
 
       if (targetRow >= 0) {
@@ -376,11 +378,13 @@ export class SelectionManager {
         this.startCell = this.initialFocusedCell!;
       }
 
-      let targetRow = rowIndex + 1;
-
-      if (event.ctrlKey || event.metaKey) {
-        const edge = this.findEdgeInDirection(rowIndex, colIndex, "down");
-        targetRow = edge.rowIndex;
+      let targetRow: number;
+      if (rowIndex < this.startCell.rowIndex) {
+        // Collapse selection downwards back to the anchor row
+        targetRow = this.startCell.rowIndex;
+      } else {
+        // Expand selection downwards all the way to the bottom
+        targetRow = this.config.tableRows.length - 1;
       }
 
       if (targetRow < this.config.tableRows.length) {
@@ -416,15 +420,13 @@ export class SelectionManager {
         this.startCell = this.initialFocusedCell!;
       }
 
-      let targetCol = colIndex - 1;
-
-      if (event.ctrlKey || event.metaKey) {
-        const edge = this.findEdgeInDirection(rowIndex, colIndex, "left");
-        targetCol = edge.colIndex;
+      let targetCol: number;
+      if (colIndex > this.startCell.colIndex) {
+        // Collapse selection to the left back to the anchor column
+        targetCol = this.startCell.colIndex;
       } else {
-        if (this.config.enableRowSelection && targetCol === 0) {
-          return;
-        }
+        // Expand selection to the left all the way to the first column
+        targetCol = this.config.enableRowSelection ? 1 : 0;
       }
 
       if (targetCol >= 0) {
@@ -470,11 +472,13 @@ export class SelectionManager {
         this.startCell = this.initialFocusedCell!;
       }
 
-      let targetCol = colIndex + 1;
-
-      if (event.ctrlKey || event.metaKey) {
-        const edge = this.findEdgeInDirection(rowIndex, colIndex, "right");
-        targetCol = edge.colIndex;
+      let targetCol: number;
+      if (colIndex < this.startCell.colIndex) {
+        // Collapse selection to the right back to the anchor column
+        targetCol = this.startCell.colIndex;
+      } else {
+        // Expand selection to the right all the way to the last column
+        targetCol = maxColIndex;
       }
 
       if (targetCol <= maxColIndex) {

--- a/packages/core/src/managers/SelectionManager/types.ts
+++ b/packages/core/src/managers/SelectionManager/types.ts
@@ -3,6 +3,8 @@ import type { Accessor } from "../../types/HeaderObject";
 import type TableRowType from "../../types/TableRow";
 import type Cell from "../../types/Cell";
 import type { CustomTheme } from "../../types/CustomTheme";
+import type { RowSelectionConfig } from "../../types/SimpleTableProps";
+import type { RowSelectionManager } from "../RowSelectionManager";
 
 export const createSetString = ({ rowIndex, colIndex, rowId }: Cell) =>
   `${rowIndex}-${colIndex}-${rowId}`;
@@ -28,4 +30,6 @@ export interface SelectionManagerConfig {
   onSelectionDragEnd?: () => void;
   /** Root element of the table; sync scopes cell queries to this so only this table's cells are updated. */
   tableRoot?: HTMLElement;
+  rowSelectionConfig?: RowSelectionConfig;
+  rowSelectionManager?: RowSelectionManager | null;
 }

--- a/packages/core/src/managers/TableManager.ts
+++ b/packages/core/src/managers/TableManager.ts
@@ -14,6 +14,7 @@ import { ColumnManager, ColumnManagerConfig } from "./ColumnManager";
 import { DimensionManager, DimensionManagerConfig } from "./DimensionManager";
 import { ScrollManager, ScrollManagerConfig } from "./ScrollManager";
 import { SelectionManager, SelectionManagerConfig } from "./SelectionManager";
+import { TableInitializer } from "../core/initialization/TableInitializer";
 
 export interface TableManagerConfig {
   headers: HeaderObject[];
@@ -72,6 +73,7 @@ export class TableManager {
   public selectionManager: SelectionManager;
 
   constructor(config: TableManagerConfig) {
+    config = TableInitializer.resolveConfigDefaults(config);
     this.config = config;
     
     this.state = {
@@ -218,7 +220,7 @@ export class TableManager {
   }
 
   updateConfig(config: Partial<TableManagerConfig>): void {
-    this.config = { ...this.config, ...config };
+    this.config = TableInitializer.resolveConfigDefaults({ ...this.config, ...config });
 
     if (config.headers !== undefined) {
       this.sortManager.updateConfig({ headers: config.headers });

--- a/packages/core/src/types/ColumnEditorConfig.ts
+++ b/packages/core/src/types/ColumnEditorConfig.ts
@@ -31,6 +31,8 @@ export interface ColumnEditorConfig {
   rowRenderer?: ColumnEditorRowRenderer;
   /** Custom renderer for the entire column editor panel. Receives pre-built sections (search, list, reset) and headers. */
   customRenderer?: ColumnEditorCustomRenderer;
+  /** Hides the column editor side toggle completely. Default: false */
+  hideToggle?: boolean;
 }
 
 export const DEFAULT_COLUMN_EDITOR_CONFIG: Required<
@@ -40,10 +42,11 @@ export const DEFAULT_COLUMN_EDITOR_CONFIG: Required<
   searchEnabled: true,
   searchPlaceholder: "Search columns...",
   allowColumnPinning: true,
+  hideToggle: false,
 };
 
 /** Column editor config with defaults applied (text, searchEnabled, searchPlaceholder are required) */
 export type MergedColumnEditorConfig = Required<
-  Pick<ColumnEditorConfig, "text" | "searchEnabled" | "searchPlaceholder" | "allowColumnPinning">
+  Pick<ColumnEditorConfig, "text" | "searchEnabled" | "searchPlaceholder" | "allowColumnPinning" | "hideToggle">
 > &
   Pick<ColumnEditorConfig, "searchFunction" | "rowRenderer" | "customRenderer">;

--- a/packages/core/src/types/SimpleTableConfig.ts
+++ b/packages/core/src/types/SimpleTableConfig.ts
@@ -24,6 +24,7 @@ import { VanillaIconsConfig } from "./IconsConfig";
 import { QuickFilterConfig } from "./QuickFilterTypes";
 import { AnimationsConfig } from "./AnimationsConfig";
 import type { FooterPosition } from "./FooterPosition";
+import { RowSelectionConfig } from "./SimpleTableProps";
 
 export interface SimpleTableConfig {
   animations?: AnimationsConfig;
@@ -95,4 +96,5 @@ export interface SimpleTableConfig {
   useHoverRowBackground?: boolean;
   useOddColumnBackground?: boolean;
   useOddEvenRowBackground?: boolean;
+  rowSelectionConfig?: RowSelectionConfig;
 }

--- a/packages/core/src/types/SimpleTableProps.ts
+++ b/packages/core/src/types/SimpleTableProps.ts
@@ -95,4 +95,16 @@ export interface SimpleTableProps {
   useHoverRowBackground?: boolean; // Flag for using hover row background
   useOddColumnBackground?: boolean; // Flag for using column background
   useOddEvenRowBackground?: boolean; // Flag for using odd/even row background
+  rowSelectionConfig?: RowSelectionConfig; // Configuration for advanced row selection settings
+}
+
+export interface RowSelectionConfig {
+  /** Whether to show the checkbox column. Default: true */
+  showCheckboxes?: boolean;
+  /** Whether clicking a row cell selects the row. Default: false (true if showCheckboxes is false) */
+  enableClickSelection?: boolean;
+  /** Whether arrow keys and home/end select rows. Default: false (true if showCheckboxes is false) */
+  enableKeyboardNavigation?: boolean;
+  /** Selection mode. Default: 'multi' */
+  mode?: 'single' | 'multi';
 }

--- a/packages/core/src/types/TableAPI.ts
+++ b/packages/core/src/types/TableAPI.ts
@@ -52,4 +52,7 @@ export type TableAPI = {
   clearSelection: () => void;
   selectCell: (cell: Cell) => void;
   selectCellRange: (startCell: Cell, endCell: Cell) => void;
+  toggleRowSelection: (rowId: string, isSelected?: boolean) => void;
+  getSelectedRows: () => string[];
+  getRow: (rowId: string) => any | null;
 };

--- a/packages/core/src/utils/bodyCell/styling.ts
+++ b/packages/core/src/utils/bodyCell/styling.ts
@@ -392,6 +392,22 @@ export const createBodyCellElement = (
     addTrackedEventListener(cellElement, "click", handleClick);
   }
 
+  // Row selection click handler
+  if (context.enableRowSelection && context.rowSelectionConfig?.enableClickSelection && !isEditing && !isSelectionColumn) {
+    const handleRowSelectionClick = (event: Event) => {
+      const mouseEvent = event as MouseEvent;
+      const target = mouseEvent.target as HTMLElement;
+      if (target.closest(".st-expand-icon-container")) return;
+
+      const clickRi = parseInt(cellElement.getAttribute("data-row-index") ?? String(rowIndex), 10);
+      const clickRid = cellElement.getAttribute("data-row-id");
+      if (clickRi < 0 || clickRid === null) return;
+
+      context.handleRowClick?.(clickRid, clickRi, mouseEvent.shiftKey, mouseEvent.ctrlKey || mouseEvent.metaKey);
+    };
+    addTrackedEventListener(cellElement, "click", handleRowSelectionClick);
+  }
+
   // Row hover handlers - use efficient Map-based tracking
   if (context.useHoverRowBackground) {
     const rowIdKey = String(rowId);

--- a/packages/core/src/utils/bodyCell/types.ts
+++ b/packages/core/src/utils/bodyCell/types.ts
@@ -14,6 +14,7 @@ import type {
   VanillaErrorStateRenderer,
   VanillaLoadingStateRenderer,
 } from "../../types/RowStateRendererProps";
+import { RowSelectionConfig } from "../../types/SimpleTableProps";
 
 type SetStateAction<T> = T | ((prevState: T) => T);
 type Dispatch<A> = (value: A) => void;
@@ -83,6 +84,7 @@ export interface CellRenderContext {
   // Configuration
   columnBorders: boolean;
   enableRowSelection?: boolean;
+  rowSelectionConfig?: RowSelectionConfig;
   /** Used for context cache invalidation when row selection changes */
   selectedRowCount?: number;
   cellUpdateFlash?: boolean;
@@ -113,6 +115,7 @@ export interface CellRenderContext {
   handleRowSelect?: (rowId: string, checked: boolean) => void;
   handleMouseDown: (cell: CellData) => void;
   handleMouseOver: (cell: CellData, clientX: number, clientY: number) => void;
+  handleRowClick?: (rowId: string, rowIndex: number, shiftKey: boolean, ctrlKey: boolean) => void;
 
   // Refs and state setters
   cellRegistry?: Map<string, CellRegistryEntry>;

--- a/packages/core/src/utils/columnEditor/createColumnEditor.ts
+++ b/packages/core/src/utils/columnEditor/createColumnEditor.ts
@@ -21,6 +21,7 @@ export interface CreateColumnEditorOptions {
   onColumnVisibilityChange?: (state: ColumnVisibilityState) => void;
   onColumnOrderChange?: (headers: HeaderObject[]) => void;
   setOpen: (open: boolean) => void;
+  hideToggle?: boolean;
 }
 
 export const createColumnEditor = (options: CreateColumnEditorOptions) => {
@@ -40,6 +41,7 @@ export const createColumnEditor = (options: CreateColumnEditorOptions) => {
     onColumnVisibilityChange,
     onColumnOrderChange,
     setOpen,
+    hideToggle,
   } = options;
 
   if (!editColumns) {
@@ -53,17 +55,26 @@ export const createColumnEditor = (options: CreateColumnEditorOptions) => {
 
   const container = document.createElement("div");
   container.className = `st-column-editor ${open ? "open" : ""}`;
-  container.style.width = `${COLUMN_EDIT_WIDTH}px`;
+  if (hideToggle) {
+    container.style.width = "0px";
+    container.style.borderLeft = "none";
+  } else {
+    container.style.width = `${COLUMN_EDIT_WIDTH}px`;
+  }
 
   const handleClick = (e: MouseEvent) => {
     setOpen(!open);
   };
 
   const textDiv = document.createElement("div");
-  textDiv.className = "st-column-editor-text";
-  textDiv.textContent = columnEditorText;
-  container.addEventListener("click", handleClick);
-  container.appendChild(textDiv);
+  if (hideToggle) {
+    textDiv.style.display = "none";
+  } else {
+    textDiv.className = "st-column-editor-text";
+    textDiv.textContent = columnEditorText;
+    container.addEventListener("click", handleClick);
+    container.appendChild(textDiv);
+  }
 
   const popout = createColumnEditorPopout({
     headers,
@@ -99,6 +110,22 @@ export const createColumnEditor = (options: CreateColumnEditorOptions) => {
 
       if (newOptions.columnEditorText !== undefined) {
         textDiv.textContent = newOptions.columnEditorText;
+      }
+
+      if (newOptions.hideToggle !== undefined) {
+        hideToggle = newOptions.hideToggle;
+        if (hideToggle) {
+          container.style.width = "0px";
+          container.style.borderLeft = "none";
+          textDiv.style.display = "none";
+          container.removeEventListener("click", handleClick);
+        } else {
+          container.style.width = `${COLUMN_EDIT_WIDTH}px`;
+          container.style.removeProperty("border-left");
+          textDiv.style.display = "";
+          textDiv.className = "st-column-editor-text";
+          container.addEventListener("click", handleClick);
+        }
       }
 
       if (newOptions.essentialAccessors !== undefined) {

--- a/packages/core/src/utils/stickyParentsRenderer.ts
+++ b/packages/core/src/utils/stickyParentsRenderer.ts
@@ -48,6 +48,7 @@ export interface StickyParentsRenderContext {
   collapsedHeaders: Set<string>;
   customTheme: CustomTheme;
   editColumns: boolean;
+  hideToggle?: boolean;
   headers: HeaderObject[];
   rowHeight: number;
   heightOffsets: HeightOffsets | undefined;
@@ -399,9 +400,8 @@ export const createStickyParentsContainer = (
       : 0;
 
   // Calculate width accounting for scrollbar
-  const containerWidth = `calc(100% - ${props.scrollbarWidth}px - ${
-    context.editColumns ? `${COLUMN_EDIT_WIDTH}px` : "0px"
-  })`;
+  const editorWidth = context.editColumns && !context.hideToggle ? COLUMN_EDIT_WIDTH : 0;
+  const containerWidth = `calc(100% - ${props.scrollbarWidth}px - ${editorWidth}px)`;
 
   // Create main container
   const container = document.createElement("div");


### PR DESCRIPTION
## Overview
This PR introduces several major features, bug fixes, and usability improvements for selection management, keyboard navigation, and the column editor.

---

## Key Changes

### 1. Advanced Row Selection & Navigation
* **Conditional Checkboxes**: Added `rowSelectionConfig.showCheckboxes` (defaults to `true`). Setting this to `false` hides the checkbox column while retaining full row selection functionality.
* **Click-to-Select**: Supported selecting rows on click (supporting `Ctrl/Cmd` for multi-select toggles and `Shift` for range selection).
* **Keyboard Navigation**: Implemented support for `ArrowUp`, `ArrowDown`, `Home`, and `End` keys to navigate and select rows when cell selection is disabled (including `Shift` for range selection).
* **Drag Selection**: Supported clicking and dragging to select a range of rows.
* **New Programmatic APIs**:
  - `toggleRowSelection(rowId: string, isSelected?: boolean)`
  - `getSelectedRows(): string[]` (returns array of selected row IDs)
  - `getRow(rowId: string): any` (returns raw row data)

### 2. Selection Auto-Resolving Defaults
* Created a helper to auto-resolve selection configurations:
  - If `selectableCells` is enabled and `selectableColumns` is undefined, `selectableColumns` is automatically set to `true`.
  - If `enableRowSelection` is active but `showCheckboxes` is `false`, cell-level selection is disabled (`selectableCells = false`) to prioritize row selection.

### 3. Shift + Arrow Cell Range Selection Refactoring
* Implemented a smart collapse-and-expand range selection mechanism when using `Shift + Arrow` keys:
  - Moving away from the anchor cell expands the selection to the outer boundaries.
  - Moving back toward the anchor cell collapses the selection.

### 4. Programmatic Column Editor & `hideToggle` Feature
* **`hideToggle` Property**: Added `hideToggle` to `columnEditorConfig` to hide the vertical toggle sidebar strip.
* **Programmatic Toggle Fix**: Converted the internal `columnEditorOpen` state in `createAPI` to a getter, resolving a bug where stale values prevented `toggleColumnEditor()` from closing the panel programmatically.
