### PR TITLE
fix(react): allow nested table columns with a different row type

### DIFF
--- a/packages/examples/angular/src/demos/column-sorting/column-sorting-demo.component.ts
+++ b/packages/examples/angular/src/demos/column-sorting/column-sorting-demo.component.ts
@@ -13,8 +13,8 @@ import "@simple-table/angular/styles.css";
       [columns]="headers"
       [height]="height"
       [theme]="theme"
-      [initialSortColumn]="initialSortColumn"
-      [initialSortDirection]="initialSortDirection"
+      initialSortColumn="age"
+      initialSortDirection="desc"
     ></simple-table>
   `,
 })
@@ -24,6 +24,4 @@ export class ColumnSortingDemoComponent {
 
   readonly rows: Row[] = columnSortingConfig.rows;
   readonly headers: AngularColumnDef[] = columnSortingConfig.headers;
-  readonly initialSortColumn = columnSortingConfig.tableProps.initialSortColumn;
-  readonly initialSortDirection = columnSortingConfig.tableProps.initialSortDirection;
 }

--- a/packages/examples/angular/src/demos/column-sorting/column-sorting.demo-data.ts
+++ b/packages/examples/angular/src/demos/column-sorting/column-sorting.demo-data.ts
@@ -140,8 +140,4 @@ export const columnSortingHeaders: AngularColumnDef[] = [
 export const columnSortingConfig = {
   headers: columnSortingHeaders,
   rows: COLUMN_SORTING_DATA,
-  tableProps: {
-    initialSortColumn: "age",
-    initialSortDirection: "desc" as const,
-  },
-} as const;
+};

--- a/packages/examples/react/src/demos/aggregate-functions/aggregate-functions.demo-data.ts
+++ b/packages/examples/react/src/demos/aggregate-functions/aggregate-functions.demo-data.ts
@@ -200,7 +200,7 @@ export const aggregateFunctionsConfig = {
   headers: aggregateFunctionsHeaders,
   rows: aggregateFunctionsData,
   tableProps: {
-    rowGrouping: ["categories", "creators"] as string[],
+    rowGrouping: ["categories", "creators"],
     columnResizing: true,
   },
 };

--- a/packages/examples/react/src/demos/collapsible-columns/collapsible-columns.demo-data.ts
+++ b/packages/examples/react/src/demos/collapsible-columns/collapsible-columns.demo-data.ts
@@ -47,15 +47,27 @@ export const collapsibleColumnsData: CollapsibleSalesRep[] = [
   { id: 12, name: "Christopher Lee", region: "Europe", q1Sales: 167000, q2Sales: 189000, q3Sales: 212000, q4Sales: 234000, totalSales: 802000, avgQuarterly: 200500, jan: 52000, feb: 55000, mar: 60000, apr: 61000, may: 63000, jun: 65000, jul: 68000, aug: 71000, sep: 73000, oct: 76000, nov: 78000, dec: 80000, avgMonthly: 66833, bestMonth: 80000, softwareSales: 320000, hardwareSales: 241000, servicesSales: 241000, topCategory: "Software", categoryCount: 3 },
 ];
 
-const fmt =
-  (accessor: keyof CollapsibleSalesRep): ReactCellRenderer<CollapsibleSalesRep> =>
-  ({ row }) =>
-    `$${((row[accessor] as number) || 0).toLocaleString()}`;
+const fmtCurrency: ReactCellRenderer<CollapsibleSalesRep, number> = ({ value }) =>
+  `$${(value ?? 0).toLocaleString()}`;
+
+type MonthKey =
+  | "jan"
+  | "feb"
+  | "mar"
+  | "apr"
+  | "may"
+  | "jun"
+  | "jul"
+  | "aug"
+  | "sep"
+  | "oct"
+  | "nov"
+  | "dec";
 
 const monthCol = (
-  accessor: keyof CollapsibleSalesRep & string,
+  accessor: MonthKey,
   label: string,
-): ReactColumnDef<CollapsibleSalesRep> => ({
+): ReactColumnDef<CollapsibleSalesRep, number> => ({
   accessor,
   label,
   width: 100,
@@ -63,7 +75,7 @@ const monthCol = (
   sortable: true,
   align: "right",
   type: "number",
-  cellRenderer: fmt(accessor),
+  cellRenderer: fmtCurrency,
 });
 
 export const collapsibleColumnsHeaders: ReactColumnDef<CollapsibleSalesRep>[] = [
@@ -77,11 +89,11 @@ export const collapsibleColumnsHeaders: ReactColumnDef<CollapsibleSalesRep>[] = 
     collapsible: true,
     collapseDefault: true,
     children: [
-      { accessor: "totalSales", label: "Total Sales", width: 140, showWhen: "parentCollapsed", sortable: true, align: "right", type: "number", cellRenderer: fmt("totalSales") },
-      { accessor: "q1Sales", label: "Q1", width: 120, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmt("q1Sales") },
-      { accessor: "q2Sales", label: "Q2", width: 120, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmt("q2Sales") },
-      { accessor: "q3Sales", label: "Q3", width: 120, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmt("q3Sales") },
-      { accessor: "q4Sales", label: "Q4", width: 120, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmt("q4Sales") },
+      { accessor: "totalSales", label: "Total Sales", width: 140, showWhen: "parentCollapsed", sortable: true, align: "right", type: "number", cellRenderer: fmtCurrency },
+      { accessor: "q1Sales", label: "Q1", width: 120, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmtCurrency },
+      { accessor: "q2Sales", label: "Q2", width: 120, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmtCurrency },
+      { accessor: "q3Sales", label: "Q3", width: 120, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmtCurrency },
+      { accessor: "q4Sales", label: "Q4", width: 120, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmtCurrency },
     ],
   },
   {
@@ -91,8 +103,8 @@ export const collapsibleColumnsHeaders: ReactColumnDef<CollapsibleSalesRep>[] = 
     collapsible: true,
     collapseDefault: true,
     children: [
-      { accessor: "avgMonthly", label: "Avg Monthly", width: 130, showWhen: "parentCollapsed", sortable: true, align: "right", type: "number", cellRenderer: fmt("avgMonthly") },
-      { accessor: "bestMonth", label: "Best Month", width: 130, showWhen: "parentCollapsed", sortable: true, align: "right", type: "number", cellRenderer: fmt("bestMonth") },
+      { accessor: "avgMonthly", label: "Avg Monthly", width: 130, showWhen: "parentCollapsed", sortable: true, align: "right", type: "number", cellRenderer: fmtCurrency },
+      { accessor: "bestMonth", label: "Best Month", width: 130, showWhen: "parentCollapsed", sortable: true, align: "right", type: "number", cellRenderer: fmtCurrency },
       monthCol("jan", "Jan"), monthCol("feb", "Feb"), monthCol("mar", "Mar"),
       monthCol("apr", "Apr"), monthCol("may", "May"), monthCol("jun", "Jun"),
       monthCol("jul", "Jul"), monthCol("aug", "Aug"), monthCol("sep", "Sep"),
@@ -107,9 +119,9 @@ export const collapsibleColumnsHeaders: ReactColumnDef<CollapsibleSalesRep>[] = 
     collapseDefault: true,
     children: [
       { accessor: "topCategory", label: "Top Category", width: 140, showWhen: "parentCollapsed", sortable: true, type: "string" },
-      { accessor: "softwareSales", label: "Software", width: 130, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmt("softwareSales") },
-      { accessor: "hardwareSales", label: "Hardware", width: 130, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmt("hardwareSales") },
-      { accessor: "servicesSales", label: "Services", width: 130, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmt("servicesSales") },
+      { accessor: "softwareSales", label: "Software", width: 130, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmtCurrency },
+      { accessor: "hardwareSales", label: "Hardware", width: 130, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmtCurrency },
+      { accessor: "servicesSales", label: "Services", width: 130, showWhen: "parentExpanded", sortable: true, align: "right", type: "number", cellRenderer: fmtCurrency },
     ],
   },
 ];

--- a/packages/examples/react/src/demos/collapsible-columns/collapsible-columns.demo-data.ts
+++ b/packages/examples/react/src/demos/collapsible-columns/collapsible-columns.demo-data.ts
@@ -1,5 +1,5 @@
 // Self-contained demo table setup for this example.
-import type { ReactColumnDef } from "@simple-table/react";
+import type { ReactCellRenderer, ReactColumnDef } from "@simple-table/react";
 
 export interface CollapsibleSalesRep {
   id: number;
@@ -48,8 +48,8 @@ export const collapsibleColumnsData: CollapsibleSalesRep[] = [
 ];
 
 const fmt =
-  (accessor: keyof CollapsibleSalesRep) =>
-  ({ row }: { row: CollapsibleSalesRep }) =>
+  (accessor: keyof CollapsibleSalesRep): ReactCellRenderer<CollapsibleSalesRep> =>
+  ({ row }) =>
     `$${((row[accessor] as number) || 0).toLocaleString()}`;
 
 const monthCol = (

--- a/packages/examples/react/src/demos/column-sorting/ColumnSortingDemo.tsx
+++ b/packages/examples/react/src/demos/column-sorting/ColumnSortingDemo.tsx
@@ -17,8 +17,8 @@ const ColumnSortingDemo = ({
       height={height}
       theme={theme}
       getRowId={({ row }) => row.id}
-      initialSortColumn={columnSortingConfig.tableProps.initialSortColumn}
-      initialSortDirection={columnSortingConfig.tableProps.initialSortDirection}
+      initialSortColumn="age"
+      initialSortDirection="desc"
     />
   );
 };

--- a/packages/examples/react/src/demos/column-sorting/column-sorting.demo-data.ts
+++ b/packages/examples/react/src/demos/column-sorting/column-sorting.demo-data.ts
@@ -149,10 +149,7 @@ export const columnSortingConfig = {
   rows: COLUMN_SORTING_DATA,
   tableProps: {
     initialSortColumn: "age",
-    initialSortDirection: "desc",
-  } satisfies {
-    initialSortColumn: string;
-    initialSortDirection: "asc" | "desc";
+    initialSortDirection: "desc" as const,
   },
 };
 

--- a/packages/examples/react/src/demos/column-sorting/column-sorting.demo-data.ts
+++ b/packages/examples/react/src/demos/column-sorting/column-sorting.demo-data.ts
@@ -147,9 +147,5 @@ export const columnSortingHeaders: ReactColumnDef<FacultyMember>[] = [
 export const columnSortingConfig = {
   headers: columnSortingHeaders,
   rows: COLUMN_SORTING_DATA,
-  tableProps: {
-    initialSortColumn: "age",
-    initialSortDirection: "desc" as const,
-  },
 };
 

--- a/packages/examples/react/src/demos/custom-theme/custom-theme.demo-data.ts
+++ b/packages/examples/react/src/demos/custom-theme/custom-theme.demo-data.ts
@@ -47,7 +47,6 @@ export const customThemeConfig = {
   headers: customThemeHeaders,
   rows: customThemeData,
   tableProps: {
-    theme: "custom",
     customTheme: {
       rowHeight: 40,
       headerHeight: 44,

--- a/packages/examples/react/src/demos/dynamic-nested-tables/DynamicNestedTablesDemo.tsx
+++ b/packages/examples/react/src/demos/dynamic-nested-tables/DynamicNestedTablesDemo.tsx
@@ -60,7 +60,7 @@ const DynamicNestedTablesDemo = ({
       expandAll={dynamicNestedTablesConfig.tableProps.expandAll}
       height={height}
       rowGrouping={dynamicNestedTablesConfig.tableProps.rowGrouping}
-      getRowId={dynamicNestedTablesConfig.tableProps.getRowId}
+      getRowId={({ row }) => row.id}
       rows={rows}
       onRowGroupExpand={handleCompanyExpand}
       theme={theme}

--- a/packages/examples/react/src/demos/dynamic-nested-tables/dynamic-nested-tables.demo-data.ts
+++ b/packages/examples/react/src/demos/dynamic-nested-tables/dynamic-nested-tables.demo-data.ts
@@ -24,8 +24,22 @@ const simulateDelay = (ms: number) => new Promise((resolve) => setTimeout(resolv
 export const fetchDivisionsForCompany = async (companyId: string): Promise<DynamicDivision[]> => {
   await simulateDelay(800);
   const divisionCount = Math.floor(Math.random() * 3) + 2;
-  const divisionNames = ["Cloud Services", "AI Research", "Consumer Products", "Investment Banking", "Operations", "Engineering"];
-  const locations = ["San Francisco, CA", "New York, NY", "Boston, MA", "Seattle, WA", "Austin, TX", "Chicago, IL"];
+  const divisionNames = [
+    "Cloud Services",
+    "AI Research",
+    "Consumer Products",
+    "Investment Banking",
+    "Operations",
+    "Engineering",
+  ];
+  const locations = [
+    "San Francisco, CA",
+    "New York, NY",
+    "Boston, MA",
+    "Seattle, WA",
+    "Austin, TX",
+    "Chicago, IL",
+  ];
 
   return Array.from({ length: divisionCount }, (_, i) => ({
     id: `${companyId}-div-${i}`,
@@ -38,21 +52,111 @@ export const fetchDivisionsForCompany = async (companyId: string): Promise<Dynam
 };
 
 export const dynamicNestedTablesData: DynamicCompany[] = [
-  { id: "comp-1", companyName: "TechCorp Global", industry: "Technology", revenue: "$250M", employees: 1200 },
-  { id: "comp-2", companyName: "FinanceHub Inc", industry: "Financial Services", revenue: "$180M", employees: 850 },
-  { id: "comp-3", companyName: "HealthTech Solutions", industry: "Healthcare", revenue: "$320M", employees: 1500 },
-  { id: "comp-4", companyName: "RetailMax Corporation", industry: "Retail", revenue: "$420M", employees: 2100 },
-  { id: "comp-5", companyName: "EnergyFlow Systems", industry: "Energy", revenue: "$560M", employees: 1800 },
-  { id: "comp-6", companyName: "MediaVision Studios", industry: "Entertainment", revenue: "$290M", employees: 950 },
-  { id: "comp-7", companyName: "AutoDrive Industries", industry: "Automotive", revenue: "$680M", employees: 3200 },
-  { id: "comp-8", companyName: "CloudNet Services", industry: "Technology", revenue: "$195M", employees: 720 },
-  { id: "comp-9", companyName: "HealthCare Solutions", industry: "Healthcare", revenue: "$380M", employees: 1300 },
-  { id: "comp-10", companyName: "EducationTech Innovations", industry: "Education", revenue: "$240M", employees: 1050 },
-  { id: "comp-11", companyName: "EnergyFlow Systems", industry: "Energy", revenue: "$560M", employees: 1800 },
-  { id: "comp-12", companyName: "EnergyFlow Systems", industry: "Energy", revenue: "$560M", employees: 1800 },
-  { id: "comp-13", companyName: "EnergyFlow Systems", industry: "Energy", revenue: "$560M", employees: 1800 },
-  { id: "comp-14", companyName: "EnergyFlow Systems", industry: "Energy", revenue: "$560M", employees: 1800 },
-  { id: "comp-15", companyName: "EnergyFlow Systems", industry: "Energy", revenue: "$560M", employees: 1800 },
+  {
+    id: "comp-1",
+    companyName: "TechCorp Global",
+    industry: "Technology",
+    revenue: "$250M",
+    employees: 1200,
+  },
+  {
+    id: "comp-2",
+    companyName: "FinanceHub Inc",
+    industry: "Financial Services",
+    revenue: "$180M",
+    employees: 850,
+  },
+  {
+    id: "comp-3",
+    companyName: "HealthTech Solutions",
+    industry: "Healthcare",
+    revenue: "$320M",
+    employees: 1500,
+  },
+  {
+    id: "comp-4",
+    companyName: "RetailMax Corporation",
+    industry: "Retail",
+    revenue: "$420M",
+    employees: 2100,
+  },
+  {
+    id: "comp-5",
+    companyName: "EnergyFlow Systems",
+    industry: "Energy",
+    revenue: "$560M",
+    employees: 1800,
+  },
+  {
+    id: "comp-6",
+    companyName: "MediaVision Studios",
+    industry: "Entertainment",
+    revenue: "$290M",
+    employees: 950,
+  },
+  {
+    id: "comp-7",
+    companyName: "AutoDrive Industries",
+    industry: "Automotive",
+    revenue: "$680M",
+    employees: 3200,
+  },
+  {
+    id: "comp-8",
+    companyName: "CloudNet Services",
+    industry: "Technology",
+    revenue: "$195M",
+    employees: 720,
+  },
+  {
+    id: "comp-9",
+    companyName: "HealthCare Solutions",
+    industry: "Healthcare",
+    revenue: "$380M",
+    employees: 1300,
+  },
+  {
+    id: "comp-10",
+    companyName: "EducationTech Innovations",
+    industry: "Education",
+    revenue: "$240M",
+    employees: 1050,
+  },
+  {
+    id: "comp-11",
+    companyName: "EnergyFlow Systems",
+    industry: "Energy",
+    revenue: "$560M",
+    employees: 1800,
+  },
+  {
+    id: "comp-12",
+    companyName: "EnergyFlow Systems",
+    industry: "Energy",
+    revenue: "$560M",
+    employees: 1800,
+  },
+  {
+    id: "comp-13",
+    companyName: "EnergyFlow Systems",
+    industry: "Energy",
+    revenue: "$560M",
+    employees: 1800,
+  },
+  {
+    id: "comp-14",
+    companyName: "EnergyFlow Systems",
+    industry: "Energy",
+    revenue: "$560M",
+    employees: 1800,
+  },
+  {
+    id: "comp-15",
+    companyName: "EnergyFlow Systems",
+    industry: "Energy",
+    revenue: "$560M",
+    employees: 1800,
+  },
 ];
 
 export const dynamicNestedTablesDivisionHeaders: ReactColumnDef<DynamicDivision>[] = [
@@ -70,8 +174,7 @@ export const dynamicNestedTablesCompanyHeaders: ReactColumnDef<DynamicCompany>[]
     width: 200,
     expandable: true,
     nestedTable: {
-      // Nested grid uses DynamicDivision; parent column tree is typed as DynamicCompany.
-      columns: dynamicNestedTablesDivisionHeaders as unknown as ReactColumnDef<DynamicCompany>[],
+      columns: dynamicNestedTablesDivisionHeaders,
       expandAll: false,
       autoExpandColumns: true,
     },
@@ -85,8 +188,7 @@ export const dynamicNestedTablesConfig = {
   headers: dynamicNestedTablesCompanyHeaders,
   rows: dynamicNestedTablesData,
   tableProps: {
-    rowGrouping: ["divisions"] as string[],
-    getRowId: ({ row }: { row: DynamicCompany }) => row.id,
+    rowGrouping: ["divisions"],
     expandAll: false,
     autoExpandColumns: true,
   },

--- a/packages/examples/react/src/demos/dynamic-row-loading/DynamicRowLoadingDemo.tsx
+++ b/packages/examples/react/src/demos/dynamic-row-loading/DynamicRowLoadingDemo.tsx
@@ -84,7 +84,7 @@ const DynamicRowLoadingDemo = ({
       height={height}
       onRowGroupExpand={handleRowExpand}
       rowGrouping={dynamicRowLoadingConfig.tableProps.rowGrouping}
-      getRowId={dynamicRowLoadingConfig.tableProps.getRowId}
+      getRowId={({ row }) => row.id}
       rows={rows}
       selectableCells={dynamicRowLoadingConfig.tableProps.selectableCells}
       theme={theme}

--- a/packages/examples/react/src/demos/dynamic-row-loading/dynamic-row-loading.demo-data.ts
+++ b/packages/examples/react/src/demos/dynamic-row-loading/dynamic-row-loading.demo-data.ts
@@ -196,8 +196,7 @@ export const generateInitialRegions = (): DynamicRegion[] => {
 export const dynamicRowLoadingConfig = {
   headers: dynamicRowLoadingHeaders,
   tableProps: {
-    rowGrouping: ["stores", "products"] as string[],
-    getRowId: ({ row }: { row: DynamicTreeRow }) => row.id,
+    rowGrouping: ["stores", "products"],
     expandAll: false,
     columnResizing: true,
     selectableCells: true,

--- a/packages/examples/react/src/demos/nested-tables/NestedTablesDemo.tsx
+++ b/packages/examples/react/src/demos/nested-tables/NestedTablesDemo.tsx
@@ -4,7 +4,6 @@ import type { Theme } from "@simple-table/react";
 import {
   nestedTablesConfig,
   generateNestedTablesData,
-  type NestedCompany
 } from "./nested-tables.demo-data";
 import "@simple-table/react/styles.css";
 
@@ -17,7 +16,7 @@ const NestedTablesDemo = ({ height = "500px", theme }: { height?: string | numbe
       columns={nestedTablesConfig.headers}
       rows={sampleData}
       rowGrouping={nestedTablesConfig.tableProps.rowGrouping}
-      getRowId={nestedTablesConfig.tableProps.getRowId}
+      getRowId={({ row }) => row.id}
       expandAll={nestedTablesConfig.tableProps.expandAll}
       columnResizing={nestedTablesConfig.tableProps.columnResizing}
       height={height}

--- a/packages/examples/react/src/demos/nested-tables/nested-tables.demo-data.ts
+++ b/packages/examples/react/src/demos/nested-tables/nested-tables.demo-data.ts
@@ -91,8 +91,7 @@ export const nestedTablesHeaders: ReactColumnDef<NestedCompany>[] = [
 export const nestedTablesConfig = {
   headers: nestedTablesHeaders,
   tableProps: {
-    rowGrouping: ["divisions"] as string[],
-    getRowId: ({ row }: { row: NestedCompany }) => row.id,
+    rowGrouping: ["divisions"],
     expandAll: false,
     columnResizing: true,
     autoExpandColumns: true,

--- a/packages/examples/react/src/demos/nested-tables/nested-tables.demo-data.ts
+++ b/packages/examples/react/src/demos/nested-tables/nested-tables.demo-data.ts
@@ -79,7 +79,7 @@ export const nestedTablesHeaders: ReactColumnDef<NestedCompany>[] = [
     width: 200,
     expandable: true,
     nestedTable: {
-      columns: nestedTablesDivisionHeaders as unknown as ReactColumnDef<NestedCompany>[],
+      columns: nestedTablesDivisionHeaders,
     },
   },
   { accessor: "stockSymbol", label: "Symbol", width: 100 },

--- a/packages/examples/react/src/demos/quick-filter/quick-filter.demo-data.ts
+++ b/packages/examples/react/src/demos/quick-filter/quick-filter.demo-data.ts
@@ -38,5 +38,4 @@ export const quickFilterData: QuickFilterEmployee[] = [
 export const quickFilterConfig = {
   headers: quickFilterHeaders,
   rows: quickFilterData,
-  tableProps: { quickFilter: { text: "", mode: "simple", caseSensitive: false } },
 };

--- a/packages/examples/react/src/demos/row-grouping/RowGroupingDemo.tsx
+++ b/packages/examples/react/src/demos/row-grouping/RowGroupingDemo.tsx
@@ -57,7 +57,7 @@ const RowGroupingDemo = ({
         rows={rowGroupingConfig.rows}
         rowGrouping={rowGroupingConfig.tableProps.rowGrouping}
         enableStickyParents={rowGroupingConfig.tableProps.enableStickyParents}
-        getRowId={rowGroupingConfig.tableProps.getRowId}
+        getRowId={({ row }) => row.id}
         columnResizing
         height={height}
         theme={theme}

--- a/packages/examples/react/src/demos/row-grouping/row-grouping.demo-data.ts
+++ b/packages/examples/react/src/demos/row-grouping/row-grouping.demo-data.ts
@@ -211,9 +211,8 @@ export const rowGroupingConfig = {
   headers: rowGroupingHeaders,
   rows: rowGroupingData,
   tableProps: {
-    rowGrouping: ["divisions", "departments"] as string[],
+    rowGrouping: ["divisions", "departments"],
     enableStickyParents: true,
-    getRowId: ({ row }: { row: OrgUnit }) => row.id,
     columnResizing: true,
   },
 };

--- a/packages/examples/solid/src/demos/column-sorting/ColumnSortingDemo.tsx
+++ b/packages/examples/solid/src/demos/column-sorting/ColumnSortingDemo.tsx
@@ -12,8 +12,8 @@ export default function ColumnSortingDemo(props: {
       rows={columnSortingConfig.rows}
       height={props.height ?? "400px"}
       theme={props.theme}
-      initialSortColumn={columnSortingConfig.tableProps.initialSortColumn}
-      initialSortDirection={columnSortingConfig.tableProps.initialSortDirection}
+      initialSortColumn="age"
+      initialSortDirection="desc"
     />
   );
 }

--- a/packages/examples/solid/src/demos/column-sorting/column-sorting.demo-data.ts
+++ b/packages/examples/solid/src/demos/column-sorting/column-sorting.demo-data.ts
@@ -140,8 +140,4 @@ export const columnSortingHeaders: SolidColumnDef[] = [
 export const columnSortingConfig = {
   headers: columnSortingHeaders,
   rows: COLUMN_SORTING_DATA,
-  tableProps: {
-    initialSortColumn: "age",
-    initialSortDirection: "desc" as const,
-  },
-} as const;
+};

--- a/packages/examples/svelte/src/demos/column-sorting/ColumnSortingDemo.svelte
+++ b/packages/examples/svelte/src/demos/column-sorting/ColumnSortingDemo.svelte
@@ -11,6 +11,6 @@
   rows={columnSortingConfig.rows}
   {height}
   {theme}
-  initialSortColumn={columnSortingConfig.tableProps.initialSortColumn}
-  initialSortDirection={columnSortingConfig.tableProps.initialSortDirection}
+  initialSortColumn="age"
+  initialSortDirection="desc"
 />

--- a/packages/examples/svelte/src/demos/column-sorting/column-sorting.demo-data.ts
+++ b/packages/examples/svelte/src/demos/column-sorting/column-sorting.demo-data.ts
@@ -140,8 +140,4 @@ export const columnSortingHeaders: SvelteColumnDef[] = [
 export const columnSortingConfig = {
   headers: columnSortingHeaders,
   rows: COLUMN_SORTING_DATA,
-  tableProps: {
-    initialSortColumn: "age",
-    initialSortDirection: "desc" as const,
-  },
-} as const;
+};

--- a/packages/examples/vanilla/src/demos/column-sorting/ColumnSortingDemo.ts
+++ b/packages/examples/vanilla/src/demos/column-sorting/ColumnSortingDemo.ts
@@ -12,8 +12,8 @@ export function renderColumnSortingDemo(
     rows: columnSortingConfig.rows,
     height: options?.height ?? "400px",
     theme: options?.theme,
-    initialSortColumn: columnSortingConfig.tableProps.initialSortColumn,
-    initialSortDirection: columnSortingConfig.tableProps.initialSortDirection,
+    initialSortColumn: "age",
+    initialSortDirection: "desc",
   });
   return table;
 }

--- a/packages/examples/vanilla/src/demos/column-sorting/column-sorting.demo-data.ts
+++ b/packages/examples/vanilla/src/demos/column-sorting/column-sorting.demo-data.ts
@@ -140,8 +140,4 @@ export const columnSortingHeaders: ColumnDef[] = [
 export const columnSortingConfig = {
   headers: columnSortingHeaders,
   rows: COLUMN_SORTING_DATA,
-  tableProps: {
-    initialSortColumn: "age",
-    initialSortDirection: "desc" as const,
-  },
-} as const;
+};

--- a/packages/examples/vue/src/demos/column-sorting/ColumnSortingDemo.vue
+++ b/packages/examples/vue/src/demos/column-sorting/ColumnSortingDemo.vue
@@ -4,8 +4,8 @@
     :rows="columnSortingConfig.rows"
     :height="height"
     :theme="theme"
-    :initial-sort-column="columnSortingConfig.tableProps.initialSortColumn"
-    :initial-sort-direction="columnSortingConfig.tableProps.initialSortDirection"
+    initial-sort-column="age"
+    initial-sort-direction="desc"
   />
 </template>
 

--- a/packages/examples/vue/src/demos/column-sorting/column-sorting.demo-data.ts
+++ b/packages/examples/vue/src/demos/column-sorting/column-sorting.demo-data.ts
@@ -140,8 +140,4 @@ export const columnSortingHeaders: VueColumnDef[] = [
 export const columnSortingConfig = {
   headers: columnSortingHeaders,
   rows: COLUMN_SORTING_DATA,
-  tableProps: {
-    initialSortColumn: "age",
-    initialSortDirection: "desc" as const,
-  },
-} as const;
+};

--- a/packages/react/src/__tests__/genericRowData.types.test.ts
+++ b/packages/react/src/__tests__/genericRowData.types.test.ts
@@ -63,9 +63,54 @@ const loose: SimpleTableReactProps = {
 };
 void loose;
 
+// Nested grid: child columns typed as Division assign under a Company column
+// with no cast / helper (nestedTable.columns is open at the boundary).
+interface NestCompany {
+  id: string;
+  name: string;
+  divisions?: NestDivision[];
+}
+interface NestDivision {
+  id: string;
+  divisionName: string;
+}
+
+const divisionColumns: ReactColumnDef<NestDivision>[] = [
+  {
+    accessor: "divisionName",
+    label: "Division",
+    width: 120,
+    cellRenderer: ({ row }) => {
+      const name: string = row.divisionName;
+      // @ts-expect-error NestDivision has no company-only fields
+      const missing: string = row.companyName;
+      void missing;
+      return name;
+    },
+  },
+];
+
+const companyColumns: ReactColumnDef<NestCompany>[] = [
+  {
+    accessor: "name",
+    label: "Company",
+    width: 160,
+    expandable: true,
+    nestedTable: {
+      columns: divisionColumns,
+      expandAll: false,
+    },
+  },
+];
+void companyColumns;
+
 describe("generic row data types", () => {
   it("compiles typed SimpleTable props and ref", () => {
     expect(columns[0]?.accessor).toBe("fullName");
     expect(ref.current).toBeNull();
+  });
+
+  it("accepts differently typed nested columns without casts", () => {
+    expect(companyColumns[0]?.nestedTable?.columns?.[0]?.accessor).toBe("divisionName");
   });
 });

--- a/packages/react/src/__tests__/genericRowData.types.test.ts
+++ b/packages/react/src/__tests__/genericRowData.types.test.ts
@@ -8,6 +8,7 @@ import { SimpleTable } from "../index";
 import type {
   TableAPI,
   ReactColumnDef,
+  NestedReactColumnDef,
   CellChangeProps,
   SimpleTableReactProps,
 } from "../index";
@@ -103,6 +104,14 @@ const companyColumns: ReactColumnDef<NestCompany>[] = [
   },
 ];
 void companyColumns;
+
+// Non-column objects are rejected at the nest boundary.
+const notAColumn = { foo: 1 };
+const badNestedColumns: NestedReactColumnDef[] = [
+  // @ts-expect-error nest columns require column metadata (accessor, label, …)
+  notAColumn,
+];
+void badNestedColumns;
 
 describe("generic row data types", () => {
   it("compiles typed SimpleTable props and ref", () => {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,7 @@ export type {
   SimpleTableReactProps,
   TableInstance,
   ReactColumnDef,
+  NestedTableReactConfig,
   ReactColumnEditorConfig,
   ReactIconsConfig,
   ReactIconElement,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,7 @@ export type {
   SimpleTableReactProps,
   TableInstance,
   ReactColumnDef,
+  NestedReactColumnDef,
   NestedTableReactConfig,
   ReactColumnEditorConfig,
   ReactIconsConfig,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -158,6 +158,27 @@ export interface ReactColumnEditorConfig extends Omit<
   customRenderer?: ReactColumnEditorCustomRenderer;
 }
 
+// ─── Nested table config ─────────────────────────────────────────────────────
+/**
+ * Nested grid props (no `rows` / inherited state renderers).
+ *
+ * Child row shape may differ from the parent column's `TData` (e.g. company →
+ * division). `columns` is intentionally open so `ReactColumnDef<Child>[]`
+ * assigns without casts; each column array is still checked at its own
+ * declaration site.
+ */
+export type NestedTableReactConfig = Omit<
+  SimpleTableReactProps,
+  | "rows"
+  | "columns"
+  | "loadingStateRenderer"
+  | "errorStateRenderer"
+  | "emptyStateRenderer"
+  | "tableEmptyStateRenderer"
+> & {
+  columns?: ReadonlyArray<ReactColumnDef<any, any>>;
+};
+
 // ─── ColumnDef override ────────────────────────────────────────────────────
 /**
  * Column definition for `columns`: same column metadata as core
@@ -173,15 +194,8 @@ export interface ReactColumnDef<
   cellRenderer?: ReactCellRenderer<TData, TValue>;
   headerRenderer?: ReactHeaderRenderer<TData>;
   children?: ReadonlyArray<ReactColumnDef<TData, any>>;
-  /** Nested grid: React table props minus row data and inherited state renderers. */
-  nestedTable?: Omit<
-    SimpleTableReactProps<TData>,
-    | "rows"
-    | "loadingStateRenderer"
-    | "errorStateRenderer"
-    | "emptyStateRenderer"
-    | "tableEmptyStateRenderer"
-  >;
+  /** Nested grid; child columns may use a different row type than `TData`. */
+  nestedTable?: NestedTableReactConfig;
 }
 
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -158,27 +158,6 @@ export interface ReactColumnEditorConfig extends Omit<
   customRenderer?: ReactColumnEditorCustomRenderer;
 }
 
-// ─── Nested table config ─────────────────────────────────────────────────────
-/**
- * Nested grid props (no `rows` / inherited state renderers).
- *
- * Child row shape may differ from the parent column's `TData` (e.g. company →
- * division). `columns` is intentionally open so `ReactColumnDef<Child>[]`
- * assigns without casts; each column array is still checked at its own
- * declaration site.
- */
-export type NestedTableReactConfig = Omit<
-  SimpleTableReactProps,
-  | "rows"
-  | "columns"
-  | "loadingStateRenderer"
-  | "errorStateRenderer"
-  | "emptyStateRenderer"
-  | "tableEmptyStateRenderer"
-> & {
-  columns?: ReadonlyArray<ReactColumnDef<any, any>>;
-};
-
 // ─── ColumnDef override ────────────────────────────────────────────────────
 /**
  * Column definition for `columns`: same column metadata as core
@@ -255,6 +234,48 @@ export interface SimpleTableReactProps<
   /** Per-row action buttons; each entry returns JSX rendered into the row's selection column. */
   rowButtons?: ReactRowButton<TData>[];
 }
+
+// ─── Nested table config ─────────────────────────────────────────────────────
+/**
+ * TData-bound call signatures omitted at nest boundaries so
+ * `ReactColumnDef<Child>[]` assigns under a parent column without casts/`any`.
+ * Child columns stay fully checked at their own declaration site.
+ */
+type ReactColumnDefCallbacks =
+  | "cellRenderer"
+  | "headerRenderer"
+  | "children"
+  | "nestedTable"
+  | "comparator"
+  | "exportValueGetter"
+  | "valueFormatter"
+  | "valueGetter"
+  | "quickFilterGetter";
+
+/** Column shape accepted on nested grids — metadata only, no TData-bound callbacks. */
+export type NestedReactColumnDef = Omit<
+  ReactColumnDef<ReactDefaultRowData>,
+  ReactColumnDefCallbacks
+> & {
+  children?: ReadonlyArray<NestedReactColumnDef>;
+  nestedTable?: NestedTableReactConfig;
+};
+
+/**
+ * Nested grid props (no `rows` / inherited state renderers).
+ * Child row shape may differ from the parent column's `TData`.
+ */
+export type NestedTableReactConfig = Omit<
+  SimpleTableReactProps,
+  | "rows"
+  | "columns"
+  | "loadingStateRenderer"
+  | "errorStateRenderer"
+  | "emptyStateRenderer"
+  | "tableEmptyStateRenderer"
+> & {
+  columns?: ReadonlyArray<NestedReactColumnDef>;
+};
 
 // Re-export vanilla prop types that consumers still need directly
 export type {


### PR DESCRIPTION
Open nestedTable.columns so ReactColumnDef<Child>[] assigns under a parent column without casts; wire getRowId next to rows in the dynamic-nested demo.