### PR TITLE
Sync pivot StackBlitz demos with panel and mode toggle

### DIFF
--- a/apps/marketing/public/txt-demos/angular/pivot.txt
+++ b/apps/marketing/public/txt-demos/angular/pivot.txt
@@ -11,26 +11,45 @@ import { pivotDemoConfig } from "./pivot.demo-data";
 import type { PivotFact } from "./pivot.demo-data";
 import "@simple-table/angular/styles.css";
 
+const INITIAL_PIVOT: PivotConfig = {
+  rows: ["region", "product"],
+  columns: ["quarter"],
+  values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+};
+
 @Component({
   selector: "pivot-demo",
   standalone: true,
   imports: [SimpleTableComponent],
   template: `
-    <simple-table
-      [getRowId]="getRowId"
-      [rows]="rows"
-      [columns]="headers"
-      [pivot]="pivot"
-      [onPivotChange]="onPivotChange"
-      [autoExpandColumns]="true"
-      [columnResizing]="true"
-      [enableColumnEditor]="true"
-      [enableColumnEditorInitOpen]="true"
-      [enablePivotPanel]="true"
-      [height]="height"
-      [selectableCells]="true"
-      [theme]="theme"
-    ></simple-table>
+    <div>
+      <label
+        style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px; font-size: 14px; color: #374151"
+      >
+        <input
+          type="checkbox"
+          [checked]="pivotEnabled"
+          aria-label="Pivot mode"
+          (change)="onPivotEnabledChange($any($event.target).checked)"
+        />
+        Pivot mode
+      </label>
+      <simple-table
+        [getRowId]="getRowId"
+        [rows]="rows"
+        [columns]="headers"
+        [pivot]="pivotEnabled ? pivot : null"
+        [onPivotChange]="onPivotChange"
+        [autoExpandColumns]="true"
+        [columnResizing]="true"
+        [enableColumnEditor]="true"
+        [enableColumnEditorInitOpen]="true"
+        [enablePivotPanel]="pivotEnabled"
+        [height]="height"
+        [selectableCells]="true"
+        [theme]="theme"
+      ></simple-table>
+    </div>
   `,
 })
 export class PivotDemoComponent {
@@ -40,11 +59,15 @@ export class PivotDemoComponent {
   readonly rows: PivotFact[] = pivotDemoConfig.rows;
   readonly headers: AngularColumnDef<PivotFact>[] = pivotDemoConfig.headers;
 
-  pivot: PivotConfig | null = {
-    rows: ["region", "product"],
-    columns: ["quarter"],
-    values: [{ accessor: "sales", aggregation: { type: "sum" } }],
-  };
+  pivotEnabled = true;
+  pivot: PivotConfig | null = INITIAL_PIVOT;
+
+  onPivotEnabledChange(enabled: boolean): void {
+    this.pivotEnabled = enabled;
+    if (enabled && this.pivot === null) {
+      this.pivot = INITIAL_PIVOT;
+    }
+  }
 
   onPivotChange = (next: PivotConfig | null) => {
     this.pivot = next;
@@ -53,3 +76,192 @@ export class PivotDemoComponent {
   getRowId = ({ row }: GetRowIdParams<PivotFact>) =>
     row?.id == null ? undefined : String(row.id);
 }
+
+
+// pivot.demo-data.ts
+import type { PivotConfig, AngularColumnDef, ValueFormatterProps } from "@simple-table/angular";
+
+export interface PivotFact {
+  id: string;
+  region: string;
+  country: string;
+  category: string;
+  product: string;
+  channel: string;
+  year: number;
+  quarter: string;
+  sales: number;
+  units: number;
+  cost: number;
+}
+
+export const pivotHeaders: AngularColumnDef<PivotFact>[] = [
+  { accessor: "region", label: "Region", width: 110, type: "string" },
+  { accessor: "country", label: "Country", width: 100, type: "string" },
+  { accessor: "category", label: "Category", width: 110, type: "string" },
+  { accessor: "product", label: "Product", width: 120, type: "string" },
+  { accessor: "channel", label: "Channel", width: 100, type: "string" },
+  { accessor: "year", label: "Year", width: 80, type: "number" },
+  { accessor: "quarter", label: "Quarter", width: 80, type: "string" },
+  {
+    accessor: "sales",
+    label: "Sales",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }: ValueFormatterProps<PivotFact>) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+  {
+    accessor: "units",
+    label: "Units",
+    width: 80,
+    type: "number",
+    align: "right",
+  },
+  {
+    accessor: "cost",
+    label: "Cost",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }: ValueFormatterProps<PivotFact>) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+];
+
+const COUNTRIES = {
+  West: ["USA", "Canada"],
+  East: ["USA", "UK"],
+  North: ["Canada", "Sweden"],
+  South: ["Brazil", "Australia"],
+};
+const PRODUCTS = {
+  Hardware: ["Widget", "Gadget", "Sensor"],
+  Software: ["License", "Subscription"],
+};
+const CHANNELS = ["Direct", "Partner", "Online"];
+const YEARS = [2024, 2025];
+const QUARTERS = ["Q1", "Q2", "Q3", "Q4"];
+
+/** Sparse multi-dimension fact cube (~150–250 rows). */
+export function generatePivotRows(): PivotFact[] {
+  const rows: PivotFact[] = [];
+  let id = 1;
+  for (const [region, countries] of Object.entries(COUNTRIES)) {
+    for (const country of countries) {
+      for (const [category, products] of Object.entries(PRODUCTS)) {
+        for (const product of products) {
+          for (const channel of CHANNELS) {
+            for (const year of YEARS) {
+              for (const quarter of QUARTERS) {
+                // Sparse facts — skip ~1/3 of combinations
+                if ((id + year + quarter.charCodeAt(1) + channel.length) % 5 !== 0) {
+                  id++;
+                  continue;
+                }
+                const base = 40 + ((id * 17) % 90);
+                rows.push({
+                  id: `r${id}`,
+                  region,
+                  country,
+                  category,
+                  product,
+                  channel,
+                  year,
+                  quarter,
+                  sales: base * 100,
+                  units: base,
+                  cost: Math.round(base * 55),
+                });
+                id++;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return rows;
+}
+
+export const pivotRows: PivotFact[] = generatePivotRows();
+
+export type PivotPreset = {
+  id: string;
+  label: string;
+  pivot: PivotConfig;
+};
+
+export const pivotPresets: PivotPreset[] = [
+  {
+    id: "region-quarter",
+    label: "Region × Quarter",
+    pivot: {
+      rows: ["region"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "multi-rows",
+    label: "Region × Product",
+    pivot: {
+      rows: ["region", "product"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "category-year-quarter",
+    label: "Category × Year → Quarter",
+    pivot: {
+      rows: ["category"],
+      columns: ["year", "quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "channel-quarter",
+    label: "Channel × Quarter",
+    pivot: {
+      rows: ["channel"],
+      columns: ["quarter"],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" }, label: "Sales" },
+        { accessor: "units", aggregation: { type: "sum" }, label: "Units" },
+      ],
+    },
+  },
+  {
+    id: "country-category",
+    label: "Country × Category",
+    pivot: {
+      rows: ["country"],
+      columns: ["category"],
+      values: [{ accessor: "sales", aggregation: { type: "average" } }],
+      showColumnTotals: false,
+    },
+  },
+  {
+    id: "values-only",
+    label: "Values only",
+    pivot: {
+      rows: ["region", "category"],
+      columns: [],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" } },
+        { accessor: "cost", aggregation: { type: "sum" } },
+      ],
+    },
+  },
+];
+
+export const pivotConfig: PivotConfig = pivotPresets[0].pivot;
+
+export const pivotDemoConfig = {
+  headers: pivotHeaders,
+  rows: pivotRows,
+  tableProps: { pivot: pivotConfig },
+  presets: pivotPresets,
+};

--- a/apps/marketing/public/txt-demos/react/pivot.txt
+++ b/apps/marketing/public/txt-demos/react/pivot.txt
@@ -1,3 +1,4 @@
+// PivotDemo.tsx
 import { useState } from "react";
 import { SimpleTable } from "@simple-table/react";
 import type { PivotConfig, Theme } from "@simple-table/react";
@@ -17,25 +18,242 @@ const PivotDemo = ({
   height?: string | number;
   theme?: Theme;
 }) => {
+  const [pivotEnabled, setPivotEnabled] = useState(true);
   const [pivot, setPivot] = useState<PivotConfig | null>(INITIAL_PIVOT);
 
+  const handlePivotEnabledChange = (enabled: boolean) => {
+    setPivotEnabled(enabled);
+    if (enabled && pivot === null) {
+      setPivot(INITIAL_PIVOT);
+    }
+  };
+
   return (
-    <SimpleTable
-      columns={pivotDemoConfig.headers}
-      rows={pivotDemoConfig.rows}
-      autoExpandColumns
-      columnResizing
-      enableColumnEditor
-      enableColumnEditorInitOpen
-      enablePivotPanel
-      height={height}
-      pivot={pivot}
-      onPivotChange={setPivot}
-      selectableCells
-      theme={theme}
-      getRowId={({ row }) => (row?.id == null ? undefined : String(row.id))}
-    />
+    <div>
+      <label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 12,
+          fontSize: 14,
+          color: "#374151",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={pivotEnabled}
+          onChange={(e) => handlePivotEnabledChange(e.target.checked)}
+          aria-label="Pivot mode"
+        />
+        Pivot mode
+      </label>
+      <SimpleTable
+        columns={pivotDemoConfig.headers}
+        rows={pivotDemoConfig.rows}
+        autoExpandColumns
+        columnResizing
+        enableColumnEditor
+        enableColumnEditorInitOpen
+        enablePivotPanel={pivotEnabled}
+        height={height}
+        pivot={pivotEnabled ? pivot : null}
+        onPivotChange={setPivot}
+        selectableCells
+        theme={theme}
+        getRowId={({ row }) => (row?.id == null ? undefined : String(row.id))}
+      />
+    </div>
   );
 };
 
 export default PivotDemo;
+
+
+// pivot.demo-data.ts
+import type { PivotConfig, ReactColumnDef } from "@simple-table/react";
+
+export interface PivotFact {
+  id: string;
+  region: string;
+  country: string;
+  category: string;
+  product: string;
+  channel: string;
+  year: number;
+  quarter: string;
+  sales: number;
+  units: number;
+  cost: number;
+}
+
+export const pivotHeaders: ReactColumnDef<PivotFact>[] = [
+  { accessor: "region", label: "Region", width: 110, type: "string" },
+  { accessor: "country", label: "Country", width: 100, type: "string" },
+  { accessor: "category", label: "Category", width: 110, type: "string" },
+  { accessor: "product", label: "Product", width: 120, type: "string" },
+  { accessor: "channel", label: "Channel", width: 100, type: "string" },
+  { accessor: "year", label: "Year", width: 80, type: "number" },
+  { accessor: "quarter", label: "Quarter", width: 80, type: "string" },
+  {
+    accessor: "sales",
+    label: "Sales",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+  {
+    accessor: "units",
+    label: "Units",
+    width: 80,
+    type: "number",
+    align: "right",
+  },
+  {
+    accessor: "cost",
+    label: "Cost",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+];
+
+const COUNTRIES = {
+  West: ["USA", "Canada"],
+  East: ["USA", "UK"],
+  North: ["Canada", "Sweden"],
+  South: ["Brazil", "Australia"],
+};
+const PRODUCTS = {
+  Hardware: ["Widget", "Gadget", "Sensor"],
+  Software: ["License", "Subscription"],
+};
+const CHANNELS = ["Direct", "Partner", "Online"];
+const YEARS = [2024, 2025];
+const QUARTERS = ["Q1", "Q2", "Q3", "Q4"];
+
+/** Sparse multi-dimension fact cube (~150–250 rows). */
+export function generatePivotRows(): PivotFact[] {
+  const rows: PivotFact[] = [];
+  let id = 1;
+  for (const [region, countries] of Object.entries(COUNTRIES)) {
+    for (const country of countries) {
+      for (const [category, products] of Object.entries(PRODUCTS)) {
+        for (const product of products) {
+          for (const channel of CHANNELS) {
+            for (const year of YEARS) {
+              for (const quarter of QUARTERS) {
+                // Sparse facts — skip ~1/3 of combinations
+                if ((id + year + quarter.charCodeAt(1) + channel.length) % 5 !== 0) {
+                  id++;
+                  continue;
+                }
+                const base = 40 + ((id * 17) % 90);
+                rows.push({
+                  id: `r${id}`,
+                  region,
+                  country,
+                  category,
+                  product,
+                  channel,
+                  year,
+                  quarter,
+                  sales: base * 100,
+                  units: base,
+                  cost: Math.round(base * 55),
+                });
+                id++;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return rows;
+}
+
+export const pivotRows: PivotFact[] = generatePivotRows();
+
+export type PivotPreset = {
+  id: string;
+  label: string;
+  pivot: PivotConfig;
+};
+
+export const pivotPresets: PivotPreset[] = [
+  {
+    id: "region-quarter",
+    label: "Region × Quarter",
+    pivot: {
+      rows: ["region"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "multi-rows",
+    label: "Region × Product",
+    pivot: {
+      rows: ["region", "product"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "category-year-quarter",
+    label: "Category × Year → Quarter",
+    pivot: {
+      rows: ["category"],
+      columns: ["year", "quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "channel-quarter",
+    label: "Channel × Quarter",
+    pivot: {
+      rows: ["channel"],
+      columns: ["quarter"],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" }, label: "Sales" },
+        { accessor: "units", aggregation: { type: "sum" }, label: "Units" },
+      ],
+    },
+  },
+  {
+    id: "country-category",
+    label: "Country × Category",
+    pivot: {
+      rows: ["country"],
+      columns: ["category"],
+      values: [{ accessor: "sales", aggregation: { type: "average" } }],
+      showColumnTotals: false,
+    },
+  },
+  {
+    id: "values-only",
+    label: "Values only",
+    pivot: {
+      rows: ["region", "category"],
+      columns: [],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" } },
+        { accessor: "cost", aggregation: { type: "sum" } },
+      ],
+    },
+  },
+];
+
+export const pivotConfig: PivotConfig = pivotPresets[0].pivot;
+
+export const pivotDemoConfig = {
+  headers: pivotHeaders,
+  rows: pivotRows,
+  tableProps: { pivot: pivotConfig },
+  presets: pivotPresets,
+};

--- a/apps/marketing/public/txt-demos/solid/pivot.txt
+++ b/apps/marketing/public/txt-demos/solid/pivot.txt
@@ -1,3 +1,4 @@
+// PivotDemo.tsx
 import { createSignal } from "solid-js";
 import { SimpleTable } from "@simple-table/solid";
 import type { PivotConfig, Theme } from "@simple-table/solid";
@@ -14,23 +15,240 @@ export default function PivotDemo(props: {
   height?: string | number;
   theme?: Theme;
 }) {
+  const [pivotEnabled, setPivotEnabled] = createSignal(true);
   const [pivot, setPivot] = createSignal<PivotConfig | null>(INITIAL_PIVOT);
 
+  const handlePivotEnabledChange = (enabled: boolean) => {
+    setPivotEnabled(enabled);
+    if (enabled && pivot() === null) {
+      setPivot(INITIAL_PIVOT);
+    }
+  };
+
   return (
-    <SimpleTable
-      columns={pivotDemoConfig.headers}
-      rows={pivotDemoConfig.rows}
-      autoExpandColumns
-      columnResizing
-      enableColumnEditor
-      enableColumnEditorInitOpen
-      enablePivotPanel
-      height={props.height ?? "500px"}
-      pivot={pivot()}
-      onPivotChange={setPivot}
-      selectableCells
-      theme={props.theme}
-      getRowId={({ row }) => (row?.id == null ? undefined : String(row.id))}
-    />
+    <div>
+      <label
+        style={{
+          display: "flex",
+          "align-items": "center",
+          gap: "8px",
+          "margin-bottom": "12px",
+          "font-size": "14px",
+          color: "#374151",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={pivotEnabled()}
+          onChange={(e) => handlePivotEnabledChange(e.currentTarget.checked)}
+          aria-label="Pivot mode"
+        />
+        Pivot mode
+      </label>
+      <SimpleTable
+        columns={pivotDemoConfig.headers}
+        rows={pivotDemoConfig.rows}
+        autoExpandColumns
+        columnResizing
+        enableColumnEditor
+        enableColumnEditorInitOpen
+        enablePivotPanel={pivotEnabled()}
+        height={props.height ?? "500px"}
+        pivot={pivotEnabled() ? pivot() : null}
+        onPivotChange={setPivot}
+        selectableCells
+        theme={props.theme}
+        getRowId={({ row }) => (row?.id == null ? undefined : String(row.id))}
+      />
+    </div>
   );
 }
+
+
+// pivot.demo-data.ts
+import type { PivotConfig, SolidColumnDef } from "@simple-table/solid";
+
+export interface PivotFact {
+  id: string;
+  region: string;
+  country: string;
+  category: string;
+  product: string;
+  channel: string;
+  year: number;
+  quarter: string;
+  sales: number;
+  units: number;
+  cost: number;
+}
+
+export const pivotHeaders: SolidColumnDef<PivotFact>[] = [
+  { accessor: "region", label: "Region", width: 110, type: "string" },
+  { accessor: "country", label: "Country", width: 100, type: "string" },
+  { accessor: "category", label: "Category", width: 110, type: "string" },
+  { accessor: "product", label: "Product", width: 120, type: "string" },
+  { accessor: "channel", label: "Channel", width: 100, type: "string" },
+  { accessor: "year", label: "Year", width: 80, type: "number" },
+  { accessor: "quarter", label: "Quarter", width: 80, type: "string" },
+  {
+    accessor: "sales",
+    label: "Sales",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+  {
+    accessor: "units",
+    label: "Units",
+    width: 80,
+    type: "number",
+    align: "right",
+  },
+  {
+    accessor: "cost",
+    label: "Cost",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+];
+
+const COUNTRIES = {
+  West: ["USA", "Canada"],
+  East: ["USA", "UK"],
+  North: ["Canada", "Sweden"],
+  South: ["Brazil", "Australia"],
+};
+const PRODUCTS = {
+  Hardware: ["Widget", "Gadget", "Sensor"],
+  Software: ["License", "Subscription"],
+};
+const CHANNELS = ["Direct", "Partner", "Online"];
+const YEARS = [2024, 2025];
+const QUARTERS = ["Q1", "Q2", "Q3", "Q4"];
+
+/** Sparse multi-dimension fact cube (~150–250 rows). */
+export function generatePivotRows(): PivotFact[] {
+  const rows: PivotFact[] = [];
+  let id = 1;
+  for (const [region, countries] of Object.entries(COUNTRIES)) {
+    for (const country of countries) {
+      for (const [category, products] of Object.entries(PRODUCTS)) {
+        for (const product of products) {
+          for (const channel of CHANNELS) {
+            for (const year of YEARS) {
+              for (const quarter of QUARTERS) {
+                // Sparse facts — skip ~1/3 of combinations
+                if ((id + year + quarter.charCodeAt(1) + channel.length) % 5 !== 0) {
+                  id++;
+                  continue;
+                }
+                const base = 40 + ((id * 17) % 90);
+                rows.push({
+                  id: `r${id}`,
+                  region,
+                  country,
+                  category,
+                  product,
+                  channel,
+                  year,
+                  quarter,
+                  sales: base * 100,
+                  units: base,
+                  cost: Math.round(base * 55),
+                });
+                id++;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return rows;
+}
+
+export const pivotRows: PivotFact[] = generatePivotRows();
+
+export type PivotPreset = {
+  id: string;
+  label: string;
+  pivot: PivotConfig;
+};
+
+export const pivotPresets: PivotPreset[] = [
+  {
+    id: "region-quarter",
+    label: "Region × Quarter",
+    pivot: {
+      rows: ["region"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "multi-rows",
+    label: "Region × Product",
+    pivot: {
+      rows: ["region", "product"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "category-year-quarter",
+    label: "Category × Year → Quarter",
+    pivot: {
+      rows: ["category"],
+      columns: ["year", "quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "channel-quarter",
+    label: "Channel × Quarter",
+    pivot: {
+      rows: ["channel"],
+      columns: ["quarter"],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" }, label: "Sales" },
+        { accessor: "units", aggregation: { type: "sum" }, label: "Units" },
+      ],
+    },
+  },
+  {
+    id: "country-category",
+    label: "Country × Category",
+    pivot: {
+      rows: ["country"],
+      columns: ["category"],
+      values: [{ accessor: "sales", aggregation: { type: "average" } }],
+      showColumnTotals: false,
+    },
+  },
+  {
+    id: "values-only",
+    label: "Values only",
+    pivot: {
+      rows: ["region", "category"],
+      columns: [],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" } },
+        { accessor: "cost", aggregation: { type: "sum" } },
+      ],
+    },
+  },
+];
+
+export const pivotConfig: PivotConfig = pivotPresets[0].pivot;
+
+export const pivotDemoConfig = {
+  headers: pivotHeaders,
+  rows: pivotRows,
+  tableProps: { pivot: pivotConfig },
+  presets: pivotPresets,
+};

--- a/apps/marketing/public/txt-demos/svelte/pivot.txt
+++ b/apps/marketing/public/txt-demos/svelte/pivot.txt
@@ -1,34 +1,247 @@
+// PivotDemo.svelte
 <script lang="ts">
   import { SimpleTable } from "@simple-table/svelte";
-  import type { GetRowIdParams, PivotConfig, Theme } from "@simple-table/svelte";
+  import type { Theme, GetRowIdParams, PivotConfig } from "@simple-table/svelte";
   import { pivotDemoConfig } from "./pivot.demo-data";
   import type { PivotFact } from "./pivot.demo-data";
   import "@simple-table/svelte/styles.css";
 
   let { height = "500px", theme }: { height?: string | number; theme?: Theme } = $props();
 
-  let pivot = $state<PivotConfig | null>({
+  const INITIAL_PIVOT: PivotConfig = {
     rows: ["region", "product"],
     columns: ["quarter"],
     values: [{ accessor: "sales", aggregation: { type: "sum" } }],
-  });
+  };
+
+  let pivotEnabled = $state(true);
+  let pivot = $state<PivotConfig | null>(INITIAL_PIVOT);
+
+  const handlePivotEnabledChange = (enabled: boolean) => {
+    pivotEnabled = enabled;
+    if (enabled && pivot === null) {
+      pivot = INITIAL_PIVOT;
+    }
+  };
 
   const getRowId = ({ row }: GetRowIdParams<PivotFact>) =>
     row?.id == null ? undefined : String(row.id);
 </script>
 
-<SimpleTable
-  columns={pivotDemoConfig.headers}
-  rows={pivotDemoConfig.rows}
-  {pivot}
-  onPivotChange={(next) => (pivot = next)}
-  autoExpandColumns={true}
-  columnResizing={true}
-  enableColumnEditor={true}
-  enableColumnEditorInitOpen={true}
-  enablePivotPanel={true}
-  selectableCells={true}
-  {getRowId}
-  {height}
-  {theme}
-/>
+<div>
+  <label
+    style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px; font-size: 14px; color: #374151"
+  >
+    <input
+      type="checkbox"
+      checked={pivotEnabled}
+      aria-label="Pivot mode"
+      onchange={(e) => handlePivotEnabledChange(e.currentTarget.checked)}
+    />
+    Pivot mode
+  </label>
+  <SimpleTable
+    columns={pivotDemoConfig.headers}
+    rows={pivotDemoConfig.rows}
+    pivot={pivotEnabled ? pivot : null}
+    onPivotChange={(next) => (pivot = next)}
+    autoExpandColumns={true}
+    columnResizing={true}
+    enableColumnEditor={true}
+    enableColumnEditorInitOpen={true}
+    enablePivotPanel={pivotEnabled}
+    selectableCells={true}
+    {getRowId}
+    {height}
+    {theme}
+  />
+</div>
+
+
+// pivot.demo-data.ts
+import type { PivotConfig, SvelteColumnDef } from "@simple-table/svelte";
+
+export interface PivotFact {
+  id: string;
+  region: string;
+  country: string;
+  category: string;
+  product: string;
+  channel: string;
+  year: number;
+  quarter: string;
+  sales: number;
+  units: number;
+  cost: number;
+}
+
+export const pivotHeaders: SvelteColumnDef<PivotFact>[] = [
+  { accessor: "region", label: "Region", width: 110, type: "string" },
+  { accessor: "country", label: "Country", width: 100, type: "string" },
+  { accessor: "category", label: "Category", width: 110, type: "string" },
+  { accessor: "product", label: "Product", width: 120, type: "string" },
+  { accessor: "channel", label: "Channel", width: 100, type: "string" },
+  { accessor: "year", label: "Year", width: 80, type: "number" },
+  { accessor: "quarter", label: "Quarter", width: 80, type: "string" },
+  {
+    accessor: "sales",
+    label: "Sales",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+  {
+    accessor: "units",
+    label: "Units",
+    width: 80,
+    type: "number",
+    align: "right",
+  },
+  {
+    accessor: "cost",
+    label: "Cost",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+];
+
+const COUNTRIES = {
+  West: ["USA", "Canada"],
+  East: ["USA", "UK"],
+  North: ["Canada", "Sweden"],
+  South: ["Brazil", "Australia"],
+};
+const PRODUCTS = {
+  Hardware: ["Widget", "Gadget", "Sensor"],
+  Software: ["License", "Subscription"],
+};
+const CHANNELS = ["Direct", "Partner", "Online"];
+const YEARS = [2024, 2025];
+const QUARTERS = ["Q1", "Q2", "Q3", "Q4"];
+
+/** Sparse multi-dimension fact cube (~150–250 rows). */
+export function generatePivotRows(): PivotFact[] {
+  const rows: PivotFact[] = [];
+  let id = 1;
+  for (const [region, countries] of Object.entries(COUNTRIES)) {
+    for (const country of countries) {
+      for (const [category, products] of Object.entries(PRODUCTS)) {
+        for (const product of products) {
+          for (const channel of CHANNELS) {
+            for (const year of YEARS) {
+              for (const quarter of QUARTERS) {
+                // Sparse facts — skip ~1/3 of combinations
+                if ((id + year + quarter.charCodeAt(1) + channel.length) % 5 !== 0) {
+                  id++;
+                  continue;
+                }
+                const base = 40 + ((id * 17) % 90);
+                rows.push({
+                  id: `r${id}`,
+                  region,
+                  country,
+                  category,
+                  product,
+                  channel,
+                  year,
+                  quarter,
+                  sales: base * 100,
+                  units: base,
+                  cost: Math.round(base * 55),
+                });
+                id++;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return rows;
+}
+
+export const pivotRows: PivotFact[] = generatePivotRows();
+
+export type PivotPreset = {
+  id: string;
+  label: string;
+  pivot: PivotConfig;
+};
+
+export const pivotPresets: PivotPreset[] = [
+  {
+    id: "region-quarter",
+    label: "Region × Quarter",
+    pivot: {
+      rows: ["region"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "multi-rows",
+    label: "Region × Product",
+    pivot: {
+      rows: ["region", "product"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "category-year-quarter",
+    label: "Category × Year → Quarter",
+    pivot: {
+      rows: ["category"],
+      columns: ["year", "quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "channel-quarter",
+    label: "Channel × Quarter",
+    pivot: {
+      rows: ["channel"],
+      columns: ["quarter"],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" }, label: "Sales" },
+        { accessor: "units", aggregation: { type: "sum" }, label: "Units" },
+      ],
+    },
+  },
+  {
+    id: "country-category",
+    label: "Country × Category",
+    pivot: {
+      rows: ["country"],
+      columns: ["category"],
+      values: [{ accessor: "sales", aggregation: { type: "average" } }],
+      showColumnTotals: false,
+    },
+  },
+  {
+    id: "values-only",
+    label: "Values only",
+    pivot: {
+      rows: ["region", "category"],
+      columns: [],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" } },
+        { accessor: "cost", aggregation: { type: "sum" } },
+      ],
+    },
+  },
+];
+
+export const pivotConfig: PivotConfig = pivotPresets[0].pivot;
+
+export const pivotDemoConfig = {
+  headers: pivotHeaders,
+  rows: pivotRows,
+  tableProps: { pivot: pivotConfig },
+  presets: pivotPresets,
+};

--- a/apps/marketing/public/txt-demos/vanilla/pivot.txt
+++ b/apps/marketing/public/txt-demos/vanilla/pivot.txt
@@ -14,11 +14,44 @@ export function renderPivotDemo(
   container: HTMLElement,
   options?: { height?: string | number; theme?: Theme }
 ): SimpleTableVanilla {
-  container.replaceChildren();
-  return new SimpleTableVanilla(container, {
+  let pivotEnabled = true;
+  let pivot: PivotConfig | null = INITIAL_PIVOT;
+  let table: SimpleTableVanilla | null = null;
+
+  const root = document.createElement("div");
+
+  const label = document.createElement("label");
+  label.style.cssText =
+    "display:flex;align-items:center;gap:8px;margin-bottom:12px;font-size:14px;color:#374151";
+
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.checked = true;
+  checkbox.setAttribute("aria-label", "Pivot mode");
+  checkbox.addEventListener("change", () => {
+    pivotEnabled = checkbox.checked;
+    if (pivotEnabled && pivot === null) {
+      pivot = INITIAL_PIVOT;
+    }
+    table?.updateConfig({
+      pivot: pivotEnabled ? pivot : null,
+      enablePivotPanel: pivotEnabled,
+    });
+  });
+
+  const text = document.createElement("span");
+  text.textContent = "Pivot mode";
+  label.append(checkbox, text);
+
+  const tableHost = document.createElement("div");
+  tableHost.style.width = "100%";
+  root.append(label, tableHost);
+  container.replaceChildren(root);
+
+  table = new SimpleTableVanilla(tableHost, {
     columns: pivotDemoConfig.headers,
     rows: pivotDemoConfig.rows,
-    pivot: INITIAL_PIVOT,
+    pivot,
     autoExpandColumns: true,
     columnResizing: true,
     enableColumnEditor: true,
@@ -28,5 +61,199 @@ export function renderPivotDemo(
     selectableCells: true,
     theme: options?.theme,
     getRowId: ({ row }) => (row?.id == null ? undefined : String(row.id)),
+    onPivotChange: (next) => {
+      pivot = next;
+    },
   });
+
+  return table;
 }
+
+
+// pivot.demo-data.ts
+import type { PivotConfig, ColumnDef } from "simple-table-core";
+
+export interface PivotFact {
+  id: string;
+  region: string;
+  country: string;
+  category: string;
+  product: string;
+  channel: string;
+  year: number;
+  quarter: string;
+  sales: number;
+  units: number;
+  cost: number;
+}
+
+export const pivotHeaders: ColumnDef<PivotFact>[] = [
+  { accessor: "region", label: "Region", width: 110, type: "string" },
+  { accessor: "country", label: "Country", width: 100, type: "string" },
+  { accessor: "category", label: "Category", width: 110, type: "string" },
+  { accessor: "product", label: "Product", width: 120, type: "string" },
+  { accessor: "channel", label: "Channel", width: 100, type: "string" },
+  { accessor: "year", label: "Year", width: 80, type: "number" },
+  { accessor: "quarter", label: "Quarter", width: 80, type: "string" },
+  {
+    accessor: "sales",
+    label: "Sales",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+  {
+    accessor: "units",
+    label: "Units",
+    width: 80,
+    type: "number",
+    align: "right",
+  },
+  {
+    accessor: "cost",
+    label: "Cost",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+];
+
+const COUNTRIES = {
+  West: ["USA", "Canada"],
+  East: ["USA", "UK"],
+  North: ["Canada", "Sweden"],
+  South: ["Brazil", "Australia"],
+};
+const PRODUCTS = {
+  Hardware: ["Widget", "Gadget", "Sensor"],
+  Software: ["License", "Subscription"],
+};
+const CHANNELS = ["Direct", "Partner", "Online"];
+const YEARS = [2024, 2025];
+const QUARTERS = ["Q1", "Q2", "Q3", "Q4"];
+
+/** Sparse multi-dimension fact cube (~150–250 rows). */
+export function generatePivotRows(): PivotFact[] {
+  const rows: PivotFact[] = [];
+  let id = 1;
+  for (const [region, countries] of Object.entries(COUNTRIES)) {
+    for (const country of countries) {
+      for (const [category, products] of Object.entries(PRODUCTS)) {
+        for (const product of products) {
+          for (const channel of CHANNELS) {
+            for (const year of YEARS) {
+              for (const quarter of QUARTERS) {
+                // Sparse facts — skip ~1/3 of combinations
+                if ((id + year + quarter.charCodeAt(1) + channel.length) % 5 !== 0) {
+                  id++;
+                  continue;
+                }
+                const base = 40 + ((id * 17) % 90);
+                rows.push({
+                  id: `r${id}`,
+                  region,
+                  country,
+                  category,
+                  product,
+                  channel,
+                  year,
+                  quarter,
+                  sales: base * 100,
+                  units: base,
+                  cost: Math.round(base * 55),
+                });
+                id++;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return rows;
+}
+
+export const pivotRows: PivotFact[] = generatePivotRows();
+
+export type PivotPreset = {
+  id: string;
+  label: string;
+  pivot: PivotConfig;
+};
+
+export const pivotPresets: PivotPreset[] = [
+  {
+    id: "region-quarter",
+    label: "Region × Quarter",
+    pivot: {
+      rows: ["region"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "multi-rows",
+    label: "Region × Product",
+    pivot: {
+      rows: ["region", "product"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "category-year-quarter",
+    label: "Category × Year → Quarter",
+    pivot: {
+      rows: ["category"],
+      columns: ["year", "quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "channel-quarter",
+    label: "Channel × Quarter",
+    pivot: {
+      rows: ["channel"],
+      columns: ["quarter"],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" }, label: "Sales" },
+        { accessor: "units", aggregation: { type: "sum" }, label: "Units" },
+      ],
+    },
+  },
+  {
+    id: "country-category",
+    label: "Country × Category",
+    pivot: {
+      rows: ["country"],
+      columns: ["category"],
+      values: [{ accessor: "sales", aggregation: { type: "average" } }],
+      showColumnTotals: false,
+    },
+  },
+  {
+    id: "values-only",
+    label: "Values only",
+    pivot: {
+      rows: ["region", "category"],
+      columns: [],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" } },
+        { accessor: "cost", aggregation: { type: "sum" } },
+      ],
+    },
+  },
+];
+
+export const pivotConfig: PivotConfig = pivotPresets[0].pivot;
+
+export const pivotDemoConfig = {
+  headers: pivotHeaders,
+  rows: pivotRows,
+  tableProps: { pivot: pivotConfig },
+  presets: pivotPresets,
+};

--- a/apps/marketing/public/txt-demos/vue/pivot.txt
+++ b/apps/marketing/public/txt-demos/vue/pivot.txt
@@ -1,19 +1,40 @@
+// PivotDemo.vue
 <template>
-  <SimpleTable
-    :columns="pivotDemoConfig.headers"
-    :rows="pivotDemoConfig.rows"
-    :pivot="pivot"
-    :onPivotChange="(next) => (pivot = next)"
-    :auto-expand-columns="true"
-    :column-resizing="true"
-    :enable-column-editor="true"
-    :enable-column-editor-init-open="true"
-    :enable-pivot-panel="true"
-    :height="height"
-    :selectable-cells="true"
-    :theme="theme"
-    :get-row-id="getRowId"
-  />
+  <div>
+    <label
+      style="
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 12px;
+        font-size: 14px;
+        color: #374151;
+      "
+    >
+      <input
+        type="checkbox"
+        :checked="pivotEnabled"
+        aria-label="Pivot mode"
+        @change="onPivotEnabledChange(($event.target as HTMLInputElement).checked)"
+      />
+      Pivot mode
+    </label>
+    <SimpleTable
+      :columns="pivotDemoConfig.headers"
+      :rows="pivotDemoConfig.rows"
+      :pivot="pivotEnabled ? pivot : null"
+      :onPivotChange="(next) => (pivot = next)"
+      :auto-expand-columns="true"
+      :column-resizing="true"
+      :enable-column-editor="true"
+      :enable-column-editor-init-open="true"
+      :enable-pivot-panel="pivotEnabled"
+      :height="height"
+      :selectable-cells="true"
+      :theme="theme"
+      :get-row-id="getRowId"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -28,12 +49,211 @@ withDefaults(defineProps<{ height?: string | number; theme?: Theme }>(), {
   height: "500px",
 });
 
-const pivot = ref<PivotConfig | null>({
+const INITIAL_PIVOT: PivotConfig = {
   rows: ["region", "product"],
   columns: ["quarter"],
   values: [{ accessor: "sales", aggregation: { type: "sum" } }],
-});
+};
+
+const pivotEnabled = ref(true);
+const pivot = ref<PivotConfig | null>(INITIAL_PIVOT);
+
+const onPivotEnabledChange = (enabled: boolean) => {
+  pivotEnabled.value = enabled;
+  if (enabled && pivot.value === null) {
+    pivot.value = INITIAL_PIVOT;
+  }
+};
 
 const getRowId = ({ row }: GetRowIdParams<PivotFact>) =>
   row?.id == null ? undefined : String(row.id);
 </script>
+
+
+// pivot.demo-data.ts
+import type { PivotConfig, VueColumnDef } from "@simple-table/vue";
+
+export interface PivotFact {
+  id: string;
+  region: string;
+  country: string;
+  category: string;
+  product: string;
+  channel: string;
+  year: number;
+  quarter: string;
+  sales: number;
+  units: number;
+  cost: number;
+}
+
+export const pivotHeaders: VueColumnDef<PivotFact>[] = [
+  { accessor: "region", label: "Region", width: 110, type: "string" },
+  { accessor: "country", label: "Country", width: 100, type: "string" },
+  { accessor: "category", label: "Category", width: 110, type: "string" },
+  { accessor: "product", label: "Product", width: 120, type: "string" },
+  { accessor: "channel", label: "Channel", width: 100, type: "string" },
+  { accessor: "year", label: "Year", width: 80, type: "number" },
+  { accessor: "quarter", label: "Quarter", width: 80, type: "string" },
+  {
+    accessor: "sales",
+    label: "Sales",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+  {
+    accessor: "units",
+    label: "Units",
+    width: 80,
+    type: "number",
+    align: "right",
+  },
+  {
+    accessor: "cost",
+    label: "Cost",
+    width: 100,
+    type: "number",
+    align: "right",
+    valueFormatter: ({ value }) =>
+      typeof value === "number" ? `$${value.toLocaleString()}` : "",
+  },
+];
+
+const COUNTRIES = {
+  West: ["USA", "Canada"],
+  East: ["USA", "UK"],
+  North: ["Canada", "Sweden"],
+  South: ["Brazil", "Australia"],
+};
+const PRODUCTS = {
+  Hardware: ["Widget", "Gadget", "Sensor"],
+  Software: ["License", "Subscription"],
+};
+const CHANNELS = ["Direct", "Partner", "Online"];
+const YEARS = [2024, 2025];
+const QUARTERS = ["Q1", "Q2", "Q3", "Q4"];
+
+/** Sparse multi-dimension fact cube (~150–250 rows). */
+export function generatePivotRows(): PivotFact[] {
+  const rows: PivotFact[] = [];
+  let id = 1;
+  for (const [region, countries] of Object.entries(COUNTRIES)) {
+    for (const country of countries) {
+      for (const [category, products] of Object.entries(PRODUCTS)) {
+        for (const product of products) {
+          for (const channel of CHANNELS) {
+            for (const year of YEARS) {
+              for (const quarter of QUARTERS) {
+                // Sparse facts — skip ~1/3 of combinations
+                if ((id + year + quarter.charCodeAt(1) + channel.length) % 5 !== 0) {
+                  id++;
+                  continue;
+                }
+                const base = 40 + ((id * 17) % 90);
+                rows.push({
+                  id: `r${id}`,
+                  region,
+                  country,
+                  category,
+                  product,
+                  channel,
+                  year,
+                  quarter,
+                  sales: base * 100,
+                  units: base,
+                  cost: Math.round(base * 55),
+                });
+                id++;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return rows;
+}
+
+export const pivotRows: PivotFact[] = generatePivotRows();
+
+export type PivotPreset = {
+  id: string;
+  label: string;
+  pivot: PivotConfig;
+};
+
+export const pivotPresets: PivotPreset[] = [
+  {
+    id: "region-quarter",
+    label: "Region × Quarter",
+    pivot: {
+      rows: ["region"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "multi-rows",
+    label: "Region × Product",
+    pivot: {
+      rows: ["region", "product"],
+      columns: ["quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "category-year-quarter",
+    label: "Category × Year → Quarter",
+    pivot: {
+      rows: ["category"],
+      columns: ["year", "quarter"],
+      values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+    },
+  },
+  {
+    id: "channel-quarter",
+    label: "Channel × Quarter",
+    pivot: {
+      rows: ["channel"],
+      columns: ["quarter"],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" }, label: "Sales" },
+        { accessor: "units", aggregation: { type: "sum" }, label: "Units" },
+      ],
+    },
+  },
+  {
+    id: "country-category",
+    label: "Country × Category",
+    pivot: {
+      rows: ["country"],
+      columns: ["category"],
+      values: [{ accessor: "sales", aggregation: { type: "average" } }],
+      showColumnTotals: false,
+    },
+  },
+  {
+    id: "values-only",
+    label: "Values only",
+    pivot: {
+      rows: ["region", "category"],
+      columns: [],
+      values: [
+        { accessor: "sales", aggregation: { type: "sum" } },
+        { accessor: "cost", aggregation: { type: "sum" } },
+      ],
+    },
+  },
+];
+
+export const pivotConfig: PivotConfig = pivotPresets[0].pivot;
+
+export const pivotDemoConfig = {
+  headers: pivotHeaders,
+  rows: pivotRows,
+  tableProps: { pivot: pivotConfig },
+  presets: pivotPresets,
+};

--- a/apps/marketing/src/components/demos/PivotDemo.tsx
+++ b/apps/marketing/src/components/demos/PivotDemo.tsx
@@ -135,11 +135,11 @@ const PivotDemo = ({
         rows={rows}
         autoExpandColumns
         columnResizing
-          enableColumnEditor
-          enableColumnEditorInitOpen
-          enablePivotPanel={pivotEnabled}
-          height={height}
-          pivot={pivotEnabled ? pivot : null}
+        enableColumnEditor
+        enableColumnEditorInitOpen
+        enablePivotPanel={pivotEnabled}
+        height={height}
+        pivot={pivotEnabled ? pivot : null}
         onPivotChange={setPivot}
         selectableCells
         theme={theme}

--- a/packages/examples/angular/src/demos/pivot/pivot-demo.component.ts
+++ b/packages/examples/angular/src/demos/pivot/pivot-demo.component.ts
@@ -1,40 +1,49 @@
 import { Component, Input } from "@angular/core";
 import { SimpleTableComponent } from "@simple-table/angular";
-import type { AngularColumnDef, GetRowIdParams, PivotConfig, Theme } from "@simple-table/angular";
-import { pivotDemoConfig, pivotPresets, type PivotPreset } from "./pivot.demo-data";
-import "@simple-table/angular/styles.css";
+import type {
+  AngularColumnDef,
+  GetRowIdParams,
+  PivotConfig,
+  Theme,
+} from "@simple-table/angular";
+import { pivotDemoConfig } from "./pivot.demo-data";
 import type { PivotFact } from "./pivot.demo-data";
+import "@simple-table/angular/styles.css";
+
+const INITIAL_PIVOT: PivotConfig = {
+  rows: ["region", "product"],
+  columns: ["quarter"],
+  values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+};
 
 @Component({
   selector: "pivot-demo",
   standalone: true,
   imports: [SimpleTableComponent],
   template: `
-    <div style="display: flex; flex-direction: column; gap: 12px; width: 100%">
-      <div style="display: flex; flex-wrap: wrap; gap: 8px">
-        @for (preset of presets; track preset.id) {
-          <button
-            type="button"
-            (click)="selectPreset(preset)"
-            [style.padding]="'6px 12px'"
-            [style.borderRadius]="'6px'"
-            [style.border]="'none'"
-            [style.cursor]="'pointer'"
-            [style.fontSize]="'13px'"
-            [style.fontWeight]="500"
-            [style.background]="preset.id === activeId ? '#2563eb' : '#e5e7eb'"
-            [style.color]="preset.id === activeId ? '#fff' : '#374151'"
-          >
-            {{ preset.label }}
-          </button>
-        }
-      </div>
+    <div>
+      <label
+        style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px; font-size: 14px; color: #374151"
+      >
+        <input
+          type="checkbox"
+          [checked]="pivotEnabled"
+          aria-label="Pivot mode"
+          (change)="onPivotEnabledChange($any($event.target).checked)"
+        />
+        Pivot mode
+      </label>
       <simple-table
-      [getRowId]="getRowId"
+        [getRowId]="getRowId"
         [rows]="rows"
         [columns]="headers"
-        [pivot]="pivot"
+        [pivot]="pivotEnabled ? pivot : null"
+        [onPivotChange]="onPivotChange"
+        [autoExpandColumns]="true"
         [columnResizing]="true"
+        [enableColumnEditor]="true"
+        [enableColumnEditorInitOpen]="true"
+        [enablePivotPanel]="pivotEnabled"
         [height]="height"
         [selectableCells]="true"
         [theme]="theme"
@@ -43,20 +52,26 @@ import type { PivotFact } from "./pivot.demo-data";
   `,
 })
 export class PivotDemoComponent {
-  @Input() height: string | number = "400px";
+  @Input() height: string | number = "500px";
   @Input() theme?: Theme;
 
   readonly rows: PivotFact[] = pivotDemoConfig.rows;
   readonly headers: AngularColumnDef<PivotFact>[] = pivotDemoConfig.headers;
-  readonly presets = pivotPresets;
 
-  activeId = pivotPresets[0].id;
-  pivot: PivotConfig = pivotPresets[0].pivot;
+  pivotEnabled = true;
+  pivot: PivotConfig | null = INITIAL_PIVOT;
 
-  selectPreset(preset: PivotPreset): void {
-    this.activeId = preset.id;
-    this.pivot = preset.pivot;
+  onPivotEnabledChange(enabled: boolean): void {
+    this.pivotEnabled = enabled;
+    if (enabled && this.pivot === null) {
+      this.pivot = INITIAL_PIVOT;
+    }
   }
 
-  getRowId = ({ row }: GetRowIdParams<PivotFact>) => row.id;
+  onPivotChange = (next: PivotConfig | null) => {
+    this.pivot = next;
+  };
+
+  getRowId = ({ row }: GetRowIdParams<PivotFact>) =>
+    row?.id == null ? undefined : String(row.id);
 }

--- a/packages/examples/react/src/demos/pivot/PivotDemo.tsx
+++ b/packages/examples/react/src/demos/pivot/PivotDemo.tsx
@@ -1,54 +1,66 @@
 import { useState } from "react";
 import { SimpleTable } from "@simple-table/react";
-import type { Theme } from "@simple-table/react";
-import { pivotDemoConfig, pivotPresets } from "./pivot.demo-data";
+import type { PivotConfig, Theme } from "@simple-table/react";
+import { pivotDemoConfig } from "./pivot.demo-data";
 import "@simple-table/react/styles.css";
 
+const INITIAL_PIVOT: PivotConfig = {
+  rows: ["region", "product"],
+  columns: ["quarter"],
+  values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+};
+
 const PivotDemo = ({
-  height = "400px",
-  theme
+  height = "500px",
+  theme,
 }: {
   height?: string | number;
   theme?: Theme;
 }) => {
-  const [activeId, setActiveId] = useState(pivotPresets[0].id);
-  const active = pivotPresets.find((p) => p.id === activeId) ?? pivotPresets[0];
+  const [pivotEnabled, setPivotEnabled] = useState(true);
+  const [pivot, setPivot] = useState<PivotConfig | null>(INITIAL_PIVOT);
+
+  const handlePivotEnabledChange = (enabled: boolean) => {
+    setPivotEnabled(enabled);
+    if (enabled && pivot === null) {
+      setPivot(INITIAL_PIVOT);
+    }
+  };
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
-        {pivotPresets.map((preset) => {
-          const selected = preset.id === activeId;
-          return (
-            <button
-              key={preset.id}
-              type="button"
-              onClick={() => setActiveId(preset.id)}
-              style={{
-                padding: "6px 12px",
-                borderRadius: 6,
-                border: "none",
-                cursor: "pointer",
-                fontSize: 13,
-                fontWeight: 500,
-                background: selected ? "#2563eb" : "#e5e7eb",
-                color: selected ? "#fff" : "#374151"
-              }}
-            >
-              {preset.label}
-            </button>
-          );
-        })}
-      </div>
+    <div>
+      <label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 12,
+          fontSize: 14,
+          color: "#374151",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={pivotEnabled}
+          onChange={(e) => handlePivotEnabledChange(e.target.checked)}
+          aria-label="Pivot mode"
+        />
+        Pivot mode
+      </label>
       <SimpleTable
         columns={pivotDemoConfig.headers}
         rows={pivotDemoConfig.rows}
-        pivot={active.pivot}
+        autoExpandColumns
         columnResizing
+        enableColumnEditor
+        enableColumnEditorInitOpen
+        enablePivotPanel={pivotEnabled}
         height={height}
+        pivot={pivotEnabled ? pivot : null}
+        onPivotChange={setPivot}
         selectableCells
         theme={theme}
-        getRowId={({ row }) => row.id}
+        getRowId={({ row }) => (row?.id == null ? undefined : String(row.id))}
       />
     </div>
   );

--- a/packages/examples/solid/src/demos/pivot/PivotDemo.tsx
+++ b/packages/examples/solid/src/demos/pivot/PivotDemo.tsx
@@ -1,54 +1,63 @@
-import { createMemo, createSignal, For } from "solid-js";
+import { createSignal } from "solid-js";
 import { SimpleTable } from "@simple-table/solid";
-import type { Theme } from "@simple-table/solid";
-import { pivotDemoConfig, pivotPresets } from "./pivot.demo-data";
+import type { PivotConfig, Theme } from "@simple-table/solid";
+import { pivotDemoConfig } from "./pivot.demo-data";
 import "@simple-table/solid/styles.css";
+
+const INITIAL_PIVOT: PivotConfig = {
+  rows: ["region", "product"],
+  columns: ["quarter"],
+  values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+};
 
 export default function PivotDemo(props: {
   height?: string | number;
   theme?: Theme;
 }) {
-  const [activeId, setActiveId] = createSignal(pivotPresets[0].id);
-  const active = createMemo(
-    () => pivotPresets.find((p) => p.id === activeId()) ?? pivotPresets[0]
-  );
+  const [pivotEnabled, setPivotEnabled] = createSignal(true);
+  const [pivot, setPivot] = createSignal<PivotConfig | null>(INITIAL_PIVOT);
+
+  const handlePivotEnabledChange = (enabled: boolean) => {
+    setPivotEnabled(enabled);
+    if (enabled && pivot() === null) {
+      setPivot(INITIAL_PIVOT);
+    }
+  };
 
   return (
-    <div style={{ display: "flex", "flex-direction": "column", gap: "12px", width: "100%" }}>
-      <div style={{ display: "flex", "flex-wrap": "wrap", gap: "8px" }}>
-        <For each={pivotPresets}>
-          {(preset) => {
-            const selected = () => preset.id === activeId();
-            return (
-              <button
-                type="button"
-                onClick={() => setActiveId(preset.id)}
-                style={{
-                  padding: "6px 12px",
-                  "border-radius": "6px",
-                  border: "none",
-                  cursor: "pointer",
-                  "font-size": "13px",
-                  "font-weight": 500,
-                  background: selected() ? "#2563eb" : "#e5e7eb",
-                  color: selected() ? "#fff" : "#374151",
-                }}
-              >
-                {preset.label}
-              </button>
-            );
-          }}
-        </For>
-      </div>
+    <div>
+      <label
+        style={{
+          display: "flex",
+          "align-items": "center",
+          gap: "8px",
+          "margin-bottom": "12px",
+          "font-size": "14px",
+          color: "#374151",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={pivotEnabled()}
+          onChange={(e) => handlePivotEnabledChange(e.currentTarget.checked)}
+          aria-label="Pivot mode"
+        />
+        Pivot mode
+      </label>
       <SimpleTable
         columns={pivotDemoConfig.headers}
-        getRowId={({ row }) => row.id}
         rows={pivotDemoConfig.rows}
-        pivot={active().pivot}
+        autoExpandColumns
         columnResizing
-        height={props.height ?? "400px"}
+        enableColumnEditor
+        enableColumnEditorInitOpen
+        enablePivotPanel={pivotEnabled()}
+        height={props.height ?? "500px"}
+        pivot={pivotEnabled() ? pivot() : null}
+        onPivotChange={setPivot}
         selectableCells
         theme={props.theme}
+        getRowId={({ row }) => (row?.id == null ? undefined : String(row.id))}
       />
     </div>
   );

--- a/packages/examples/svelte/src/demos/pivot/PivotDemo.svelte
+++ b/packages/examples/svelte/src/demos/pivot/PivotDemo.svelte
@@ -1,39 +1,56 @@
 <script lang="ts">
   import { SimpleTable } from "@simple-table/svelte";
-  import type { Theme, GetRowIdParams } from "@simple-table/svelte";
-  import { pivotDemoConfig, pivotPresets } from "./pivot.demo-data";
+  import type { Theme, GetRowIdParams, PivotConfig } from "@simple-table/svelte";
+  import { pivotDemoConfig } from "./pivot.demo-data";
   import type { PivotFact } from "./pivot.demo-data";
   import "@simple-table/svelte/styles.css";
 
-  let { height = "400px", theme }: { height?: string | number; theme?: Theme } = $props();
+  let { height = "500px", theme }: { height?: string | number; theme?: Theme } = $props();
 
-  let activeId = $state(pivotPresets[0].id);
-  const active = $derived(pivotPresets.find((p) => p.id === activeId) ?? pivotPresets[0]);
-  const getRowId = ({ row }: GetRowIdParams<PivotFact>) => row.id;
+  const INITIAL_PIVOT: PivotConfig = {
+    rows: ["region", "product"],
+    columns: ["quarter"],
+    values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+  };
+
+  let pivotEnabled = $state(true);
+  let pivot = $state<PivotConfig | null>(INITIAL_PIVOT);
+
+  const handlePivotEnabledChange = (enabled: boolean) => {
+    pivotEnabled = enabled;
+    if (enabled && pivot === null) {
+      pivot = INITIAL_PIVOT;
+    }
+  };
+
+  const getRowId = ({ row }: GetRowIdParams<PivotFact>) =>
+    row?.id == null ? undefined : String(row.id);
 </script>
 
-<div style="display: flex; flex-direction: column; gap: 12px; width: 100%">
-  <div style="display: flex; flex-wrap: wrap; gap: 8px">
-    {#each pivotPresets as preset}
-      <button
-        type="button"
-        onclick={() => (activeId = preset.id)}
-        style="padding: 6px 12px; border-radius: 6px; border: none; cursor: pointer; font-size: 13px; font-weight: 500; background: {preset.id ===
-        activeId
-          ? '#2563eb'
-          : '#e5e7eb'}; color: {preset.id === activeId ? '#fff' : '#374151'}"
-      >
-        {preset.label}
-      </button>
-    {/each}
-  </div>
+<div>
+  <label
+    style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px; font-size: 14px; color: #374151"
+  >
+    <input
+      type="checkbox"
+      checked={pivotEnabled}
+      aria-label="Pivot mode"
+      onchange={(e) => handlePivotEnabledChange(e.currentTarget.checked)}
+    />
+    Pivot mode
+  </label>
   <SimpleTable
     columns={pivotDemoConfig.headers}
     rows={pivotDemoConfig.rows}
-    pivot={active.pivot}
-    {getRowId}
+    pivot={pivotEnabled ? pivot : null}
+    onPivotChange={(next) => (pivot = next)}
+    autoExpandColumns={true}
     columnResizing={true}
+    enableColumnEditor={true}
+    enableColumnEditorInitOpen={true}
+    enablePivotPanel={pivotEnabled}
     selectableCells={true}
+    {getRowId}
     {height}
     {theme}
   />

--- a/packages/examples/vanilla/src/demos/pivot/PivotDemo.ts
+++ b/packages/examples/vanilla/src/demos/pivot/PivotDemo.ts
@@ -1,62 +1,69 @@
 import { SimpleTableVanilla } from "simple-table-core";
-import type { PivotFact } from "./pivot.demo-data";
-import type { Theme, GetRowIdParams } from "simple-table-core";
-import { pivotDemoConfig, pivotPresets } from "./pivot.demo-data";
+import type { PivotConfig, Theme } from "simple-table-core";
+import { pivotDemoConfig } from "./pivot.demo-data";
 import "simple-table-core/styles.css";
 
-const getRowId = ({ row }: GetRowIdParams<PivotFact>) => row.id;
+const INITIAL_PIVOT: PivotConfig = {
+  rows: ["region", "product"],
+  columns: ["quarter"],
+  values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+};
+
 export function renderPivotDemo(
   container: HTMLElement,
   options?: { height?: string | number; theme?: Theme }
-): SimpleTableVanilla<PivotFact> {
-  let activeId = pivotPresets[0].id;
-  let table: SimpleTableVanilla<PivotFact> | null = null;
+): SimpleTableVanilla {
+  let pivotEnabled = true;
+  let pivot: PivotConfig | null = INITIAL_PIVOT;
+  let table: SimpleTableVanilla | null = null;
 
   const root = document.createElement("div");
-  root.style.cssText = "display:flex;flex-direction:column;gap:12px;width:100%";
 
-  const buttons = document.createElement("div");
-  buttons.style.cssText = "display:flex;flex-wrap:wrap;gap:8px";
+  const label = document.createElement("label");
+  label.style.cssText =
+    "display:flex;align-items:center;gap:8px;margin-bottom:12px;font-size:14px;color:#374151";
+
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.checked = true;
+  checkbox.setAttribute("aria-label", "Pivot mode");
+  checkbox.addEventListener("change", () => {
+    pivotEnabled = checkbox.checked;
+    if (pivotEnabled && pivot === null) {
+      pivot = INITIAL_PIVOT;
+    }
+    table?.updateConfig({
+      pivot: pivotEnabled ? pivot : null,
+      enablePivotPanel: pivotEnabled,
+    });
+  });
+
+  const text = document.createElement("span");
+  text.textContent = "Pivot mode";
+  label.append(checkbox, text);
 
   const tableHost = document.createElement("div");
-  tableHost.style.cssText = "width:100%";
-
-  const paintButtons = () => {
-    buttons.replaceChildren();
-    for (const preset of pivotPresets) {
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.textContent = preset.label;
-      const selected = preset.id === activeId;
-      btn.style.cssText = `padding:6px 12px;border-radius:6px;border:none;cursor:pointer;font-size:13px;font-weight:500;background:${
-        selected ? "#2563eb" : "#e5e7eb"
-      };color:${selected ? "#fff" : "#374151"}`;
-      btn.addEventListener("click", () => {
-        activeId = preset.id;
-        paintButtons();
-        const active = pivotPresets.find((p) => p.id === activeId) ?? pivotPresets[0];
-        table?.updateConfig({
-          pivot: active.pivot,
-        });
-      });
-      buttons.appendChild(btn);
-    }
-  };
-
-  paintButtons();
-  root.append(buttons, tableHost);
+  tableHost.style.width = "100%";
+  root.append(label, tableHost);
   container.replaceChildren(root);
 
-  const active = pivotPresets.find((p) => p.id === activeId) ?? pivotPresets[0];
   table = new SimpleTableVanilla(tableHost, {
-    getRowId,
     columns: pivotDemoConfig.headers,
     rows: pivotDemoConfig.rows,
-    pivot: active.pivot,
+    pivot,
+    autoExpandColumns: true,
     columnResizing: true,
-    height: options?.height ?? "400px",
+    enableColumnEditor: true,
+    enableColumnEditorInitOpen: true,
+    enablePivotPanel: true,
+    height: options?.height ?? "500px",
     selectableCells: true,
     theme: options?.theme,
+    getRowId: ({ row }) => (row?.id == null ? undefined : String(row.id)),
+    onPivotChange: (next) => {
+      pivot = next;
+    },
   });
+
   return table;
 }

--- a/packages/examples/vue/src/demos/pivot/PivotDemo.vue
+++ b/packages/examples/vue/src/demos/pivot/PivotDemo.vue
@@ -1,54 +1,69 @@
 <template>
-  <div style="display: flex; flex-direction: column; gap: 12px; width: 100%">
-    <div style="display: flex; flex-wrap: wrap; gap: 8px">
-      <button
-        v-for="preset in pivotPresets"
-        :key="preset.id"
-        type="button"
-        @click="activeId = preset.id"
-        :style="{
-          padding: '6px 12px',
-          borderRadius: '6px',
-          border: 'none',
-          cursor: 'pointer',
-          fontSize: '13px',
-          fontWeight: 500,
-          background: preset.id === activeId ? '#2563eb' : '#e5e7eb',
-          color: preset.id === activeId ? '#fff' : '#374151',
-        }"
-      >
-        {{ preset.label }}
-      </button>
-    </div>
+  <div>
+    <label
+      style="
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 12px;
+        font-size: 14px;
+        color: #374151;
+      "
+    >
+      <input
+        type="checkbox"
+        :checked="pivotEnabled"
+        aria-label="Pivot mode"
+        @change="onPivotEnabledChange(($event.target as HTMLInputElement).checked)"
+      />
+      Pivot mode
+    </label>
     <SimpleTable
       :columns="pivotDemoConfig.headers"
       :rows="pivotDemoConfig.rows"
-      :get-row-id="getRowId"
-      :pivot="active.pivot"
+      :pivot="pivotEnabled ? pivot : null"
+      :onPivotChange="(next) => (pivot = next)"
+      :auto-expand-columns="true"
       :column-resizing="true"
+      :enable-column-editor="true"
+      :enable-column-editor-init-open="true"
+      :enable-pivot-panel="pivotEnabled"
       :height="height"
       :selectable-cells="true"
       :theme="theme"
+      :get-row-id="getRowId"
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { ref } from "vue";
 import { SimpleTable } from "@simple-table/vue";
-import type { Theme, GetRowIdParams } from "@simple-table/vue";
-import { pivotDemoConfig, pivotPresets } from "./pivot.demo-data";
+import type { GetRowIdParams, PivotConfig, Theme } from "@simple-table/vue";
+import { pivotDemoConfig } from "./pivot.demo-data";
 import type { PivotFact } from "./pivot.demo-data";
 import "@simple-table/vue/styles.css";
 
 withDefaults(defineProps<{ height?: string | number; theme?: Theme }>(), {
-  height: "400px",
+  height: "500px",
 });
 
-const activeId = ref(pivotPresets[0].id);
-const active = computed(
-  () => pivotPresets.find((p) => p.id === activeId.value) ?? pivotPresets[0]
-);
+const INITIAL_PIVOT: PivotConfig = {
+  rows: ["region", "product"],
+  columns: ["quarter"],
+  values: [{ accessor: "sales", aggregation: { type: "sum" } }],
+};
 
-const getRowId = ({ row }: GetRowIdParams<PivotFact>) => row.id;
+const pivotEnabled = ref(true);
+const pivot = ref<PivotConfig | null>(INITIAL_PIVOT);
+
+const onPivotEnabledChange = (enabled: boolean) => {
+  pivotEnabled.value = enabled;
+  if (enabled && pivot.value === null) {
+    pivot.value = INITIAL_PIVOT;
+  }
+};
+
+const getRowId = ({ row }: GetRowIdParams<PivotFact>) =>
+  row?.id == null ? undefined : String(row.id);
 </script>


### PR DESCRIPTION
## Summary
- Update all framework pivot demos in `packages/examples` to match the docs: Pivot Panel + Pivot mode checkbox
- Refresh `public/txt-demos/*/pivot.txt` for the Code toggle
- StackBlitz `stackblitz-examples` branch already updated for `{framework}/pivot`

## Test plan
- [ ] Open `/docs/pivot` Code toggle — shows panel + pivot mode checkbox
- [ ] Open StackBlitz for react/pivot — same UI; toggle clears pivot and column editor panel
- [ ] Spot-check vue/angular StackBlitz pivot demos


Made with [Cursor](https://cursor.com)